### PR TITLE
Fix English restart bug and add Arabic translations

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -91,6 +91,22 @@ ensure_nautilus_python() {
     line "$NP_PKG" "installed"
 }
 
+ensure_gettext() {
+    if command -v msgfmt >/dev/null 2>&1; then
+        line "gettext (msgfmt)" "detected"
+        return
+    fi
+    line "gettext (msgfmt)" "not detected — installing..."
+    case "$PM" in
+        pacman) sudo pacman -S --noconfirm gettext ;;
+        apt)    sudo apt-get install -y gettext ;;
+        dnf)    sudo dnf install -y gettext ;;
+        zypper) sudo zypper install -y gettext-tools ;;
+    esac
+    command -v msgfmt >/dev/null 2>&1 || die "gettext (msgfmt) installation failed. Install gettext manually and re-run."
+    line "gettext (msgfmt)" "installed"
+}
+
 # ─── Dependency check ─────────────────────────────────────────────────────────
 check_dependencies() {
     local missing=""
@@ -124,9 +140,18 @@ download_files() {
             || die "Failed to download $EXT_FILE"
         curl -fsSL "$base/$SCHEMA_FILE" -o "$TEMP_DIR/$SCHEMA_FILE" \
             || die "Failed to download $SCHEMA_FILE"
+        
+        # Download translation files if remote
+        mkdir -p "$TEMP_DIR/po"
+        for lang in ar; do
+            curl -fsSL "$base/po/$lang.po" -o "$TEMP_DIR/po/$lang.po" || true
+        done
     else
         cp "$INSTALL_SOURCE/$EXT_FILE"    "$TEMP_DIR/$EXT_FILE"    || die "Local $EXT_FILE not found"
         cp "$INSTALL_SOURCE/$SCHEMA_FILE" "$TEMP_DIR/$SCHEMA_FILE" || die "Local $SCHEMA_FILE not found"
+        if [ -d "$INSTALL_SOURCE/po" ]; then
+            cp -r "$INSTALL_SOURCE/po" "$TEMP_DIR/"
+        fi
     fi
 
     python3 -m py_compile "$TEMP_DIR/$EXT_FILE" \
@@ -144,6 +169,19 @@ install_files() {
     cp "$TEMP_DIR/$SCHEMA_FILE" "$USER_SCHEMA_DIR/$SCHEMA_FILE"
     line "Preferences installed" "$USER_SCHEMA_DIR/$SCHEMA_FILE"
     glib-compile-schemas "$USER_SCHEMA_DIR"
+
+    # Compile and install gettext translations
+    if [ -d "$TEMP_DIR/po" ] && command -v msgfmt >/dev/null 2>&1; then
+        for po_file in "$TEMP_DIR"/po/*.po; do
+            if [ -f "$po_file" ]; then
+                lang=$(basename "$po_file" .po)
+                loc_dir="$HOME/.local/share/locale/$lang/LC_MESSAGES"
+                mkdir -p "$loc_dir"
+                msgfmt "$po_file" -o "$loc_dir/nautilus-my-computer.mo"
+                line "Translation ($lang) installed" "$loc_dir/nautilus-my-computer.mo"
+            fi
+        done
+    fi
 }
 
 # ─── Restart Nautilus ─────────────────────────────────────────────────────────
@@ -154,7 +192,11 @@ offer_restart() {
     if [[ "$answer" =~ ^[Yy]$ ]]; then
         nautilus -q >/dev/null 2>&1 || true
         sleep 1
-        (exec >/dev/null 2>&1 </dev/null; exec nautilus) &
+        if command -v gtk-launch >/dev/null 2>&1; then
+            gtk-launch org.gnome.Nautilus >/dev/null 2>&1 &
+        else
+            (exec >/dev/null 2>&1 </dev/null; exec nautilus) &
+        fi
         disown $!
     fi
 }
@@ -183,6 +225,7 @@ do_install() {
     echo ""
     detect_pm
     ensure_nautilus_python
+    ensure_gettext
     download_files
     install_files
 
@@ -210,6 +253,18 @@ do_uninstall() {
         glib-compile-schemas "$USER_SCHEMA_DIR"
         line "Preferences removed" "$USER_SCHEMA_DIR/$SCHEMA_FILE"
         found=true
+    fi
+
+    # Remove compiled translations
+    local loc_dir_prefix="$HOME/.local/share/locale"
+    if [ -d "$loc_dir_prefix" ]; then
+        for mo_file in "$loc_dir_prefix"/*/LC_MESSAGES/nautilus-my-computer.mo; do
+            if [ -f "$mo_file" ]; then
+                rm -f "$mo_file"
+                line "Translation removed" "$mo_file"
+                found=true
+            fi
+        done
     fi
 
     if [ "$found" = false ]; then

--- a/nautilus-my-computer.py
+++ b/nautilus-my-computer.py
@@ -13,7 +13,31 @@ gi.require_version("GObject", "2.0")
 gi.require_version("Gtk", "4.0")
 from gi.repository import Adw, Gdk, Gio, GLib, GObject, Gtk, Nautilus
 
-_ = gettext.translation("nautilus", fallback=True).gettext
+# Initialize gettext translations
+_custom_translation = None
+_localedir = os.path.expanduser("~/.local/share/locale")
+try:
+    _custom_translation = gettext.translation("nautilus-my-computer", localedir=_localedir)
+except Exception:
+    pass
+
+_nautilus_translation = None
+try:
+    _nautilus_translation = gettext.translation("nautilus")
+except Exception:
+    pass
+
+def _(text: str) -> str:
+    # Try custom domain first
+    if _custom_translation is not None:
+        val = _custom_translation.gettext(text)
+        if val != text:
+            return val
+    # Fallback to Nautilus domain
+    if _nautilus_translation is not None:
+        return _nautilus_translation.gettext(text)
+    # Default fallback to the string itself
+    return text
 
 DEBUG_LOG = True
 DEBUG_LOG_PREFIX = "MyComputer"  # prefix for all debug lines, to make them easy to filter in logs
@@ -28,6 +52,7 @@ EXT_GITHUB      = "https://github.com/yannmasoch/nautilus-my-computer"
 
 DISKS_URI       = "computer:///"
 BOOKMARK_LABEL  = "Computer"
+BOOKMARK_LABEL_LOCAL = _(BOOKMARK_LABEL)
 BOOKMARKS_FILE  = os.path.expanduser("~/.config/gtk-3.0/bookmarks")
 COMPUTER_ICON   = "computer-symbolic"  # icon used in sidebar and path bar
 MENU_ITEM_LABEL = "My Computer Settings"   # label in Nautilus hamburger menu
@@ -68,7 +93,7 @@ try:
     )
     _LOCATION_TITLE = _info.get_display_name()
 except Exception:
-    _LOCATION_TITLE = BOOKMARK_LABEL
+    _LOCATION_TITLE = BOOKMARK_LABEL_LOCAL
 
 # Localized title Nautilus shows when browsing the user's home folder.
 # Used to distinguish a "default new window" (opened at Home) from a window
@@ -179,7 +204,7 @@ def _log(msg: str) -> None:
         print(f"{DEBUG_LOG_PREFIX}: {msg}", flush=True)
 
 
-_log(f"Configured URI title: '{_LOCATION_TITLE}' (Bookmark: '{BOOKMARK_LABEL}')")
+_log(f"Configured URI title: '{_LOCATION_TITLE}' (Bookmark: '{BOOKMARK_LABEL}', Local: '{BOOKMARK_LABEL_LOCAL}')")
 
 
 def _get_gsettings() -> Gio.Settings | None:
@@ -430,7 +455,7 @@ def _refresh(mounts: list[dict]) -> bool:
 
 
 def _ensure_bookmark() -> None:
-    entry = f"{DISKS_URI} {BOOKMARK_LABEL}"
+    entry = f"{DISKS_URI} {BOOKMARK_LABEL_LOCAL}"
     os.makedirs(os.path.dirname(BOOKMARKS_FILE), exist_ok=True)
     lines: list[str] = []
     if os.path.exists(BOOKMARKS_FILE):
@@ -1195,7 +1220,7 @@ class MyComputerExtension(GObject.GObject, Nautilus.MenuProvider):
                 by_group[gkey] = items
 
 
-        group_labels = {key: lbl for key, lbl in _GROUPS}
+        group_labels = {key: _(lbl) for key, lbl in _GROUPS}
         size_group = Gtk.SizeGroup(mode=Gtk.SizeGroupMode.HORIZONTAL)
 
         for group_key, _group_label in _GROUPS:
@@ -1299,7 +1324,10 @@ class MyComputerExtension(GObject.GObject, Nautilus.MenuProvider):
             st = self._windows.get(win)
             if st is not None and v > 0:
                 st.setdefault("bar_geom", {})[bname] = v
-            sub_text = f"{_format_size(m['free'])} free of {_format_size(m['total'])}"
+            sub_text = _("{free} free of {total}").format(
+                free=_format_size(m['free']),
+                total=_format_size(m['total'])
+            )
         else:
             bar.set_visible(False)
             sub_text = nav_uri
@@ -1737,7 +1765,7 @@ class MyComputerExtension(GObject.GObject, Nautilus.MenuProvider):
 
         mode_row = Adw.ComboRow()
         mode_row.set_title(_("Color mode"))
-        mode_model = Gtk.StringList.new(["System accent", "Custom color", "Gradient"])
+        mode_model = Gtk.StringList.new([_( "System accent"), _("Custom color"), _("Gradient")])
         mode_row.set_model(mode_model)
         _mode_map = ["accent", "flat", "gradient"]
         current_mode = self._gsettings.get_string("color-mode")
@@ -1947,6 +1975,7 @@ class MyComputerExtension(GObject.GObject, Nautilus.MenuProvider):
             site="_fix_sidebar_icon",
         )
 
+        target_labels = {BOOKMARK_LABEL, BOOKMARK_LABEL_LOCAL, _LOCATION_TITLE}
         found = False
         if nav_box is not None:
             # Direct children of nav_box are the sidebar rows — no class name needed.
@@ -1956,7 +1985,7 @@ class MyComputerExtension(GObject.GObject, Nautilus.MenuProvider):
                     ((w.get_label() or "").strip() for w in _all_widgets(row) if isinstance(w, Gtk.Label)),
                     None,
                 )
-                if label_text == BOOKMARK_LABEL:
+                if label_text in target_labels:
                     for w in _all_widgets(row):
                         if isinstance(w, Gtk.Image):
                             _pin_icon(w, COMPUTER_ICON)
@@ -1972,7 +2001,7 @@ class MyComputerExtension(GObject.GObject, Nautilus.MenuProvider):
                     ((w.get_label() or "").strip() for w in _all_widgets(row) if isinstance(w, Gtk.Label)),
                     None,
                 )
-                if label_text == BOOKMARK_LABEL:
+                if label_text in target_labels:
                     for w in _all_widgets(row):
                         if isinstance(w, Gtk.Image):
                             _pin_icon(w, COMPUTER_ICON)
@@ -2040,7 +2069,7 @@ class MyComputerExtension(GObject.GObject, Nautilus.MenuProvider):
 
     def _subscribe_pathbar_labels(self, pathbar) -> None:
         """Connect notify::label on every GtkLabel inside *pathbar*."""
-        target_labels = {BOOKMARK_LABEL, _LOCATION_TITLE}
+        target_labels = {BOOKMARK_LABEL, BOOKMARK_LABEL_LOCAL, _LOCATION_TITLE}
         for w in _all_widgets(pathbar):
             if isinstance(w, Gtk.Label) and not getattr(w, "_diskinfo_label_watched", False):
                 w._diskinfo_label_watched = True
@@ -2058,7 +2087,7 @@ class MyComputerExtension(GObject.GObject, Nautilus.MenuProvider):
         if pathbar_or_win is None:
             return False
 
-        target_labels = {BOOKMARK_LABEL, _LOCATION_TITLE}
+        target_labels = {BOOKMARK_LABEL, BOOKMARK_LABEL_LOCAL, _LOCATION_TITLE}
         for w in _all_widgets(pathbar_or_win):
             if not isinstance(w, Gtk.Label):
                 continue

--- a/po/ar.po
+++ b/po/ar.po
@@ -1,0 +1,130 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: nautilus-my-computer\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-06-02 00:00+0300\n"
+"PO-Revision-Date: 2026-06-02 00:00+0300\n"
+"Last-Translator: Yann Masoch\n"
+"Language-Team: Arabic\n"
+"Language: ar\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=6; plural=n==0 ? 0 : n==1 ? 1 : n==2 ? 2 : n%100>=3 && n%100<=10 ? 3 : n%100>=11 ? 4 : 5;\n"
+
+msgid "My Computer Settings"
+msgstr "إعدادات جهاز الكمبيوتر"
+
+msgid "System"
+msgstr "النظام"
+
+msgid "Devices and Drives"
+msgstr "الأجهزة ومحركات الأقراص"
+
+msgid "Removable Devices"
+msgstr "الأجهزة القابلة للإزالة"
+
+msgid "Network Volumes"
+msgstr "مجلدات الشبكة"
+
+msgid "Not mounted"
+msgstr "غير موصول"
+
+msgid "Format…"
+msgstr "تهيئة…"
+
+msgid "General"
+msgstr "عام"
+
+msgid "Start on Computer view"
+msgstr "البدء في عرض الكمبيوتر"
+
+msgid "Show the disk panel when Nautilus opens"
+msgstr "إظهار لوحة الأقراص عند فتح ناوتيلوس"
+
+msgid "Disk Usage Color"
+msgstr "لون استخدام القرص"
+
+msgid "Color mode"
+msgstr "وضع اللون"
+
+msgid "System accent"
+msgstr "لون النظام المميز"
+
+msgid "Custom color"
+msgstr "لون مخصص"
+
+msgid "Gradient"
+msgstr "تدرج لوني"
+
+msgid "Color"
+msgstr "اللون"
+
+msgid "Start color"
+msgstr "لون البداية"
+
+msgid "End color"
+msgstr "لون النهاية"
+
+msgid "Sidebar Bookmark"
+msgstr "علامة الشريط الجانبي"
+
+msgid "The “Computer” bookmark gives access to this panel from the sidebar. Restore it here if you accidentally removed it."
+msgstr "تتيح علامة \"جهاز الكمبيوتر\" إمكانية الوصول إلى هذه اللوحة من الشريط الجانبي. استعدها من هنا إذا قمت بإزالتها دون قصد."
+
+msgid "Restore \"Computer\" bookmark"
+msgstr "استعادة علامة \"جهاز الكمبيوتر\""
+
+msgid "Restore"
+msgstr "استعادة"
+
+msgid "Added ✓"
+msgstr "تمت الإضافة ✓"
+
+msgid "About"
+msgstr "حول"
+
+msgid "Extension"
+msgstr "الامتداد"
+
+msgid "Version"
+msgstr "الإصدار"
+
+msgid "Author"
+msgstr "المؤلف"
+
+msgid "License"
+msgstr "الترخيص"
+
+msgid "Source code"
+msgstr "شفرة المصدر"
+
+msgid "GitHub ↗"
+msgstr "جيت هاب ↗"
+
+msgid "{free} free of {total}"
+msgstr "متوفر {free} من {total}"
+
+msgid "Computer"
+msgstr "جهاز الكمبيوتر"
+
+msgid "Mount"
+msgstr "ضم"
+
+msgid "Unmount"
+msgstr "فصل"
+
+msgid "Eject"
+msgstr "إخراج"
+
+msgid "Open"
+msgstr "افتح"
+
+msgid "Open in New Tab"
+msgstr "افتح في علامة تبويب جديدة"
+
+msgid "Open in New Window"
+msgstr "افتح في نافذة جديدة"
+
+msgid "Properties"
+msgstr "الخصائص"


### PR DESCRIPTION
This PR resolves two issues:
1. **Nautilus Language Switching on Restart:** When Nautilus is restarted via the installer, it inherits the terminal's environment, causing it to display in English if the terminal has a different locale configuration than the GNOME desktop session. This is resolved by restarting Nautilus via `gtk-launch org.gnome.Nautilus` (which is standard and part of GLib tools).
2. **Arabic Localization:** Added Arabic translation support.
   - Bound custom gettext domain `nautilus-my-computer` to the local directory `~/.local/share/locale`.
   - Defined `_` fallback wrapper: checks custom domain first, falls back to the system's `nautilus` domain for standard actions/menus, and then to default string.
   - Added `po/ar.po` with all translations.
   - Localized the `"Computer"` bookmark label to `"جهاز الكمبيوتر"` when in Arabic.
   - Localized category headers, ComboRow items, and status lines.
   - Fixed mixed LTR/RTL text order for disk status layout by starting the translation string with Arabic text (`"متوفر {free} من {total}"`).
   - Cleaned up translated `.mo` files in `do_uninstall()`.