### PR TITLE
feat: cumulative update (translations, disk cards fixes, fstype, hide…

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,11 +1,12 @@
 #!/usr/bin/env bash
 # install.sh — Nautilus My Computer Extension Installer
 #
-# Default (latest release):
+# Default (dev branch):
 #   curl -fsSL https://raw.githubusercontent.com/yannmasoch/nautilus-my-computer/main/install.sh | bash
 #
-# Pin to a specific version:
-#   VERSION=v0.2.1 curl -fsSL https://raw.githubusercontent.com/yannmasoch/nautilus-my-computer/main/install.sh | bash
+# Pin to a specific branch or tag:
+#   VERSION=main  curl -fsSL ... | bash
+#   VERSION=v0.1  curl -fsSL ... | bash
 
 main() {
 
@@ -15,14 +16,23 @@ REF_OVERRIDE="${VERSION:-}"
 
 # ─── Colors ───────────────────────────────────────────────────────────────────
 RED=$'\033[0;31m'
+GREEN=$'\033[0;32m'
+YELLOW=$'\033[0;33m'
 CYAN=$'\033[0;36m'
 BOLD=$'\033[1m'
+DIM=$'\033[2m'
 RESET=$'\033[0m'
 
-line()      { printf "%-26s" "$1"; echo -e "${CYAN}$2${RESET}"; }
-print_bye() { echo ""; echo -e "${BOLD}${CYAN}👋 Bye${RESET}"; echo ""; }
-error()     { echo -e "${RED}[ERROR]${RESET} $*" >&2; }
-die()       { error "$*"; exit 1; }
+# ─── Output helpers ───────────────────────────────────────────────────────────
+COL=30
+line()  { printf "  ${DIM}%-${COL}s${RESET}${CYAN}%s${RESET}\n" "$1" "$2"; }
+ok()    { printf "  ${GREEN}✔${RESET}  %-$((COL-3))s${CYAN}%s${RESET}\n" "$1" "$2"; }
+info()  { printf "  ${YELLOW}ℹ${RESET}  %s\n" "$*"; }
+warn()  { printf "  ${YELLOW}⚠${RESET}  ${YELLOW}%s${RESET}\n" "$*" >&2; }
+error() { printf "  ${RED}✖${RESET}  ${RED}%s${RESET}\n" "$*" >&2; }
+die()   { error "$*"; exit 1; }
+sep()   { printf "${DIM}"; printf '%0.s─' $(seq 1 44); printf "${RESET}\n"; }
+bye()   { echo; printf "${BOLD}${CYAN}  👋 Bye!${RESET}\n"; echo; }
 
 # ─── Temp dir + cleanup ───────────────────────────────────────────────────────
 TEMP_DIR=$(mktemp -d)
@@ -31,17 +41,24 @@ trap cleanup EXIT
 
 # ─── Constants ────────────────────────────────────────────────────────────────
 REPO="yannmasoch/nautilus-my-computer"
+DEFAULT_BRANCH="dev"          # branch used when no release/tag found
 EXT_DIR="$HOME/.local/share/nautilus-python/extensions"
 EXT_FILE="nautilus-my-computer.py"
+VERSION_FILE="$EXT_DIR/.nautilus-my-computer.version"
 SCHEMA_FILE="io.github.yannmasoch.nautilus-my-computer.gschema.xml"
 USER_SCHEMA_DIR="$HOME/.local/share/glib-2.0/schemas"
 
 # ─── Source detection: local clone or remote ──────────────────────────────────
-# INSTALL_SOURCE can be set externally to override auto-detection.
-# If unset: use local files when run from inside a git clone, else download.
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd || echo "")"
+SCRIPT_DIR=""
+if [[ -n "${BASH_SOURCE[0]:-}" && "${BASH_SOURCE[0]}" != "/dev/stdin" && \
+      "${BASH_SOURCE[0]}" != "bash" && -f "${BASH_SOURCE[0]}" ]]; then
+    SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd || echo "")"
+fi
+
 if [ -z "${INSTALL_SOURCE:-}" ]; then
-    if [ -n "$SCRIPT_DIR" ] && [ -f "$SCRIPT_DIR/$EXT_FILE" ] && [ -f "$SCRIPT_DIR/$SCHEMA_FILE" ]; then
+    if [ -n "$SCRIPT_DIR" ] && \
+       [ -f "$SCRIPT_DIR/$EXT_FILE" ] && \
+       [ -f "$SCRIPT_DIR/$SCHEMA_FILE" ]; then
         INSTALL_SOURCE="$SCRIPT_DIR"
     else
         INSTALL_SOURCE="remote"
@@ -52,7 +69,8 @@ fi
 ask() {
     local prompt="$1" var="$2" default="${3:-}"
     printf "%s" "$prompt" >/dev/tty
-    read -r "$var" </dev/tty
+    read -r "$var" </dev/tty || true
+    # Strip carriage return (Windows line endings)
     printf -v "$var" '%s' "${!var%$'\r'}"
     if [ -z "${!var}" ] && [ -n "$default" ]; then
         printf -v "$var" '%s' "$default"
@@ -60,95 +78,249 @@ ask() {
     fi
 }
 
+# ─── System information ───────────────────────────────────────────────────────
+detect_os() {
+    if [ -f /etc/os-release ]; then
+        . /etc/os-release
+        DISTRO_NAME="${PRETTY_NAME:-${NAME:-Unknown}}"
+        DISTRO_ID="${ID:-unknown}"
+        DISTRO_ID_LIKE="${ID_LIKE:-}"
+    elif [ -f /etc/lsb-release ]; then
+        . /etc/lsb-release
+        DISTRO_NAME="${DISTRIB_DESCRIPTION:-${DISTRIB_ID:-Unknown}}"
+        DISTRO_ID="${DISTRIB_ID:-unknown}"
+        DISTRO_ID_LIKE=""
+    else
+        DISTRO_NAME="Unknown Linux"
+        DISTRO_ID="unknown"
+        DISTRO_ID_LIKE=""
+    fi
+}
+
+get_gnome_version() {
+    local ver=""
+    if command -v gnome-shell >/dev/null 2>&1; then
+        ver=$(gnome-shell --version 2>/dev/null | grep -oP '\d+\.\d+(\.\d+)?' | head -1 || true)
+    fi
+    echo "${ver:-not detected}"
+}
+
+get_nautilus_version() {
+    local ver=""
+    if command -v nautilus >/dev/null 2>&1; then
+        ver=$(nautilus --version 2>/dev/null | grep -oP '\d+\.\d+(\.\d+)?' | head -1 || true)
+    fi
+    echo "${ver:-not detected}"
+}
+
+get_installed_version() {
+    if [ -f "$VERSION_FILE" ]; then
+        cat "$VERSION_FILE"
+    elif [ -f "$EXT_DIR/$EXT_FILE" ]; then
+        echo "installed (version unknown)"
+    else
+        echo "not installed"
+    fi
+}
+
+show_sysinfo() {
+    detect_os
+    local kernel gnome_ver nautilus_ver installed_ver
+    kernel=$(uname -r)
+    gnome_ver=$(get_gnome_version)
+    nautilus_ver=$(get_nautilus_version)
+    installed_ver=$(get_installed_version)
+
+    echo ""
+    printf "${BOLD}${CYAN}  Nautilus My Computer — Extension Installer${RESET}\n"
+    sep
+    echo ""
+    line "Distro"                 "$DISTRO_NAME"
+    line "Kernel"                 "$kernel"
+    line "GNOME Shell"            "$gnome_ver"
+    line "Nautilus"               "$nautilus_ver"
+    echo ""
+    if [ "$installed_ver" = "not installed" ]; then
+        line "Extension"          "${RED}not installed${RESET}"
+    else
+        line "Extension"          "${GREEN}${installed_ver}${RESET}"
+    fi
+    echo ""
+
+    if command -v flatpak >/dev/null 2>&1; then
+        if flatpak list 2>/dev/null | grep -qi "org.gnome.Nautilus"; then
+            warn "Flatpak Nautilus detected. This installer targets the system/native Nautilus."
+            warn "If you use the Flatpak version, extensions may not load automatically."
+            echo ""
+        fi
+    fi
+
+    case "${DISTRO_ID}${DISTRO_ID_LIKE}" in
+        *silverblue*|*kinoite*|*bazzite*|*aurora*|*ucore*|*microos*|*aeon*|*kalpa*)
+            warn "Atomic/immutable distro detected."
+            warn "System packages installed with rpm-ostree/transactional-update may be"
+            warn "needed. This installer uses user-level paths (~/.local) which should work."
+            echo "" ;;
+    esac
+
+    if [ "$gnome_ver" != "not detected" ]; then
+        local major
+        major=$(echo "$gnome_ver" | cut -d. -f1)
+        if [ "$major" -lt 40 ] 2>/dev/null; then
+            warn "GNOME ${gnome_ver} detected. This extension targets GNOME 40+."
+            warn "It may not work correctly on older versions."
+            echo ""
+        fi
+    fi
+}
+
 # ─── Package manager detection ────────────────────────────────────────────────
+PM=""
+NP_PKG=""
+
 detect_pm() {
     if   command -v pacman  >/dev/null 2>&1; then PM=pacman;  NP_PKG="python-nautilus"
     elif command -v apt-get >/dev/null 2>&1; then PM=apt;     NP_PKG="python3-nautilus"
     elif command -v dnf     >/dev/null 2>&1; then PM=dnf;     NP_PKG="nautilus-python"
     elif command -v zypper  >/dev/null 2>&1; then PM=zypper;  NP_PKG="python3-nautilus"
-    else die "Cannot detect package manager. Install the nautilus-python package manually and re-run."
+    elif command -v apk     >/dev/null 2>&1; then PM=apk;     NP_PKG="py3-nautilus"
+    elif command -v xbps-install >/dev/null 2>&1; then PM=xbps; NP_PKG="python3-nautilus"
+    else
+        die "Cannot detect package manager. Install the nautilus-python package manually and re-run."
     fi
-    line "Package Manager" "$PM detected"
+    ok "Package manager" "$PM"
 }
 
 nautilus_python_installed() {
     case "$PM" in
-        pacman) pacman -Q "$NP_PKG" >/dev/null 2>&1 ;;
-        apt)    dpkg -l "$NP_PKG"   >/dev/null 2>&1 ;;
-        dnf)    rpm -q  "$NP_PKG"   >/dev/null 2>&1 ;;
-        zypper) rpm -q  "$NP_PKG"   >/dev/null 2>&1 ;;
+        pacman) pacman -Q "$NP_PKG"     >/dev/null 2>&1 ;;
+        apt)    dpkg -l "$NP_PKG" 2>/dev/null | grep -q '^ii' ;;
+        dnf)    rpm -q  "$NP_PKG"       >/dev/null 2>&1 ;;
+        zypper) rpm -q  "$NP_PKG"       >/dev/null 2>&1 ;;
+        apk)    apk info "$NP_PKG"      >/dev/null 2>&1 ;;
+        xbps)   xbps-query "$NP_PKG"   >/dev/null 2>&1 ;;
+    esac
+}
+
+install_pkg() {
+    local pkg="$1"
+    case "$PM" in
+        pacman) sudo pacman -S --noconfirm "$pkg" ;;
+        apt)    sudo apt-get install -y "$pkg" ;;
+        dnf)    sudo dnf install -y "$pkg" ;;
+        zypper) sudo zypper install -y "$pkg" ;;
+        apk)    sudo apk add "$pkg" ;;
+        xbps)   sudo xbps-install -y "$pkg" ;;
     esac
 }
 
 ensure_nautilus_python() {
     if nautilus_python_installed; then
-        line "$NP_PKG" "detected"
+        ok "$NP_PKG" "already installed"
         return
     fi
-    line "$NP_PKG" "not detected — installing..."
-    case "$PM" in
-        pacman) sudo pacman -S --noconfirm "$NP_PKG" ;;
-        apt)    sudo apt-get install -y "$NP_PKG" python3-gi ;;
-        dnf)    sudo dnf install -y "$NP_PKG" ;;
-        zypper) sudo zypper install -y "$NP_PKG" ;;
-    esac
+    info "$NP_PKG not found — installing…"
+    if [ "$PM" = "apt" ]; then
+        sudo apt-get install -y "$NP_PKG" python3-gi
+    else
+        install_pkg "$NP_PKG"
+    fi
     nautilus_python_installed || die "$NP_PKG installation failed."
-    line "$NP_PKG" "installed"
+    ok "$NP_PKG" "installed"
 }
 
 ensure_gettext() {
     if command -v msgfmt >/dev/null 2>&1; then
-        line "gettext (msgfmt)" "detected"
+        ok "gettext (msgfmt)" "already installed"
         return
     fi
-    line "gettext (msgfmt)" "not detected — installing..."
+    info "gettext not found — installing…"
     case "$PM" in
-        pacman) sudo pacman -S --noconfirm gettext ;;
-        apt)    sudo apt-get install -y gettext ;;
-        dnf)    sudo dnf install -y gettext ;;
-        zypper) sudo zypper install -y gettext-tools ;;
+        zypper) install_pkg "gettext-tools" ;;
+        *)      install_pkg "gettext" ;;
     esac
-    command -v msgfmt >/dev/null 2>&1 || die "gettext (msgfmt) installation failed. Install gettext manually and re-run."
-    line "gettext (msgfmt)" "installed"
+    command -v msgfmt >/dev/null 2>&1 \
+        || die "gettext installation failed. Install gettext manually and re-run."
+    ok "gettext (msgfmt)" "installed"
 }
 
 # ─── Dependency check ─────────────────────────────────────────────────────────
 check_dependencies() {
-    local missing=""
-    local tools="python3 glib-compile-schemas gsettings"
-    if [ "$INSTALL_SOURCE" = "remote" ]; then tools="curl $tools"; fi
+    local missing="" tools
+    tools="python3 glib-compile-schemas gsettings"
+    [ "$INSTALL_SOURCE" = "remote" ] && tools="curl $tools"
     for tool in $tools; do
-        command -v "$tool" >/dev/null 2>&1 || missing="$missing $tool"
+        command -v "$tool" >/dev/null 2>&1 || missing="${missing:+$missing, }$tool"
     done
-    [ -z "$missing" ] || die "Required tools missing:$missing"
+    [ -z "$missing" ] || die "Required tools not found: $missing"
 }
 
-# ─── Resolve version to install ──────────────────────────────────────────────
-# Always fetches the latest published release into LATEST_RELEASE.
-# If VERSION is set, LATEST is set to that; validate_ref will fall back to
-# LATEST_RELEASE if the specified version does not exist.
+# ─── Resolve version ──────────────────────────────────────────────────────────
 LATEST=""
 LATEST_RELEASE=""
 REF_FALLBACK=false
 
+_curl_api() {
+    curl -s --max-time 10 \
+        -w "\n__HTTP_CODE__:%{http_code}" \
+        "$1" 2>/dev/null || true
+}
+_api_code() { printf '%s' "$1" | grep -o '__HTTP_CODE__:[0-9]*' | cut -d: -f2 || true; }
+_api_body() { printf '%s' "$1" | sed '/__HTTP_CODE__:/d'; }
+
 fetch_latest_version() {
-    local response
-    response=$(curl -s "https://api.github.com/repos/$REPO/releases/latest") \
-        || die "Failed to reach GitHub API."
+    # Evitar llamada a la API si ya pedimos una rama o versión específica
+    if [ -n "$REF_OVERRIDE" ]; then
+        LATEST="$REF_OVERRIDE"
+        return
+    fi
 
-    LATEST_RELEASE=$(echo "$response" | grep '"tag_name"' | sed 's/.*"tag_name": *"\(.*\)".*/\1/' || true)
-    [ -z "$LATEST_RELEASE" ] && LATEST_RELEASE="main"
+    local raw code body
 
-    LATEST="${REF_OVERRIDE:-$LATEST_RELEASE}"
+    raw=$(_curl_api "https://api.github.com/repos/$REPO/releases/latest")
+    code=$(_api_code "$raw")
+    body=$(_api_body "$raw")
+
+    case "$code" in
+        200)
+            LATEST_RELEASE=$(printf '%s' "$body" \
+                | grep '"tag_name"' \
+                | sed 's/.*"tag_name": *"\(.*\)".*/\1/' \
+                | head -1 || true)
+            ;;
+        404)
+            raw=$(_curl_api "https://api.github.com/repos/$REPO/tags")
+            code=$(_api_code "$raw")
+            body=$(_api_body "$raw")
+            if [ "$code" = "200" ]; then
+                LATEST_RELEASE=$(printf '%s' "$body" \
+                    | grep '"name"' \
+                    | sed 's/.*"name": *"\(.*\)".*/\1/' \
+                    | head -1 || true)
+            fi
+            ;;
+        403|429)
+            warn "GitHub API rate limit (HTTP $code) — using '$DEFAULT_BRANCH' branch."
+            ;;
+        "")
+            warn "No response from GitHub — check your connection. Using '$DEFAULT_BRANCH' branch."
+            ;;
+        *)
+            warn "GitHub API returned HTTP $code — using '$DEFAULT_BRANCH' branch."
+            ;;
+    esac
+
+    [ -z "$LATEST_RELEASE" ] && LATEST_RELEASE="$DEFAULT_BRANCH"
+    LATEST="$LATEST_RELEASE"
 }
 
-# ─── Validate user-specified VERSION exists on GitHub ────────────────────────
 validate_ref() {
     [ -n "$REF_OVERRIDE" ] || return
     local status
     status=$(curl -s -o /dev/null -w "%{http_code}" \
         "https://raw.githubusercontent.com/$REPO/$LATEST/$EXT_FILE")
     if [ "$status" != "200" ]; then
+        warn "Version '$REF_OVERRIDE' not found on GitHub — using latest ($LATEST_RELEASE)."
         REF_FALLBACK=true
         LATEST="$LATEST_RELEASE"
     fi
@@ -158,74 +330,85 @@ validate_ref() {
 download_files() {
     if [ "$INSTALL_SOURCE" = "remote" ]; then
         local base="https://raw.githubusercontent.com/$REPO/$LATEST"
-        curl -fsSL "$base/$EXT_FILE" -o "$TEMP_DIR/$EXT_FILE" \
-            || die "Failed to download $EXT_FILE"
-        curl -fsSL "$base/$SCHEMA_FILE" -o "$TEMP_DIR/$SCHEMA_FILE" \
-            || die "Failed to download $SCHEMA_FILE"
 
-        # Download translation files
+        curl -fsSL "$base/$EXT_FILE"    -o "$TEMP_DIR/$EXT_FILE"    \
+            || die "Failed to download $EXT_FILE from $base"
+        curl -fsSL "$base/$SCHEMA_FILE" -o "$TEMP_DIR/$SCHEMA_FILE" \
+            || die "Failed to download $SCHEMA_FILE from $base"
+
         mkdir -p "$TEMP_DIR/po"
-        langs=$(curl -fsSL "https://api.github.com/repos/$REPO/contents/po?ref=$LATEST" \
-            | grep '"name"' | sed 's/.*"name": "\(.*\)\.po".*/\1/' | grep -v '"name"') || true
+        local langs po_json
+        po_json=$(curl -sL --max-time 10 \
+            "https://api.github.com/repos/$REPO/contents/po?ref=$LATEST" \
+            2>/dev/null || true)
+        langs=$(printf '%s' "$po_json" \
+            | grep '"name"' \
+            | sed 's/.*"name": "\(.*\)\.po".*/\1/' \
+            | grep -v '"' \
+            || true)
         for lang in $langs; do
-            curl -fsSL "$base/po/$lang.po" -o "$TEMP_DIR/po/$lang.po" || true
+            curl -sL --max-time 10 "$base/po/$lang.po" -o "$TEMP_DIR/po/$lang.po" 2>/dev/null || true
         done
     else
-        cp "$INSTALL_SOURCE/$EXT_FILE"    "$TEMP_DIR/$EXT_FILE"    || die "Local $EXT_FILE not found"
-        cp "$INSTALL_SOURCE/$SCHEMA_FILE" "$TEMP_DIR/$SCHEMA_FILE" || die "Local $SCHEMA_FILE not found"
-        if [ -d "$INSTALL_SOURCE/po" ]; then
-            cp -r "$INSTALL_SOURCE/po" "$TEMP_DIR/"
-        fi
+        cp "$INSTALL_SOURCE/$EXT_FILE"    "$TEMP_DIR/$EXT_FILE"    \
+            || die "Local file not found: $INSTALL_SOURCE/$EXT_FILE"
+        cp "$INSTALL_SOURCE/$SCHEMA_FILE" "$TEMP_DIR/$SCHEMA_FILE" \
+            || die "Local file not found: $INSTALL_SOURCE/$SCHEMA_FILE"
+        [ -d "$INSTALL_SOURCE/po" ] && cp -r "$INSTALL_SOURCE/po" "$TEMP_DIR/"
     fi
 
     python3 -m py_compile "$TEMP_DIR/$EXT_FILE" \
-        || die "Extension file failed syntax check — aborting."
+        || die "Extension file failed Python syntax check — aborting."
 }
 
-# ─── Install extension + schema ───────────────────────────────────────────────
+# ─── Install extension + schema + translations ────────────────────────────────
 install_files() {
-    # Extension
     mkdir -p "$EXT_DIR"
     cp "$TEMP_DIR/$EXT_FILE" "$EXT_DIR/$EXT_FILE"
-    rm -f "$EXT_DIR/__pycache__/nautilus-my-computer.cpython-"*.pyc 2>/dev/null || true
-    line "Extension installed" "$EXT_DIR/$EXT_FILE"
+    find "$EXT_DIR/__pycache__/" -name "nautilus-my-computer.cpython-*.pyc" \
+        -delete 2>/dev/null || true
+    ok "Extension" "$EXT_DIR/$EXT_FILE"
 
-    # Schema
+    printf '%s\n' "$LATEST" > "$VERSION_FILE"
+
     mkdir -p "$USER_SCHEMA_DIR"
     cp "$TEMP_DIR/$SCHEMA_FILE" "$USER_SCHEMA_DIR/$SCHEMA_FILE"
-    line "Preferences installed" "$USER_SCHEMA_DIR/$SCHEMA_FILE"
     glib-compile-schemas "$USER_SCHEMA_DIR"
+    ok "Preferences (schema)" "$USER_SCHEMA_DIR/$SCHEMA_FILE"
 
-    # Translations (if any)
-    [ -d "$TEMP_DIR/po" ] || return
-    command -v msgfmt >/dev/null 2>&1 || return
+    [ -d "$TEMP_DIR/po" ] || return 0
+    command -v msgfmt >/dev/null 2>&1 || return 0
     local langs_installed=""
     for po_file in "$TEMP_DIR"/po/*.po; do
         [ -f "$po_file" ] || continue
+        local lang loc_dir
         lang=$(basename "$po_file" .po)
         loc_dir="$HOME/.local/share/locale/$lang/LC_MESSAGES"
         mkdir -p "$loc_dir"
-        msgfmt "$po_file" -o "$loc_dir/nautilus-my-computer.mo"
-        langs_installed="${langs_installed:+$langs_installed, }$lang"
+        msgfmt "$po_file" -o "$loc_dir/nautilus-my-computer.mo" \
+            && langs_installed="${langs_installed:+$langs_installed, }$lang" || true
     done
-    [ -n "$langs_installed" ] && line "Translations installed" "$langs_installed"
+    [ -n "$langs_installed" ] && ok "Translations" "$langs_installed"
+    return 0
 }
-
 
 # ─── Restart Nautilus ─────────────────────────────────────────────────────────
 offer_restart() {
-    echo "" >/dev/tty
+    echo ""
     local answer
-    ask "Restart Nautilus now? [Y/n]: " answer "Y"
+    ask "  Restart Nautilus now? [Y/n]: " answer "Y"
     if [[ "$answer" =~ ^[Yy]$ ]]; then
         nautilus -q >/dev/null 2>&1 || true
         sleep 1
         if command -v gtk-launch >/dev/null 2>&1; then
             gtk-launch org.gnome.Nautilus >/dev/null 2>&1 &
+        elif command -v nohup >/dev/null 2>&1; then
+            nohup nautilus >/dev/null 2>&1 &
         else
-            (exec >/dev/null 2>&1 </dev/null; exec nautilus) &
+            (exec nautilus >/dev/null 2>&1 </dev/null) &
         fi
-        disown $!
+        disown $! 2>/dev/null || true
+        ok "Nautilus" "restarted"
     fi
 }
 
@@ -237,110 +420,122 @@ do_install() {
     if [ "$INSTALL_SOURCE" = "remote" ]; then
         fetch_latest_version
         validate_ref
-        line "Installation type" "GitHub ($LATEST)"
-        if [ -n "$REF_OVERRIDE" ]; then
+        ok "Install source" "GitHub  ($LATEST)"
+        if [ -n "${VERSION:-}" ] || [ "$LATEST" = "$DEFAULT_BRANCH" ] || [ "$LATEST" = "main" ]; then
             if [ "$REF_FALLBACK" = "true" ]; then
-                line "Selected version" "${CYAN}$REF_OVERRIDE${RESET} not found - using ${CYAN}$LATEST_RELEASE${RESET}"
+                info "Requested '$REF_OVERRIDE' not found — installing $LATEST_RELEASE instead."
             else
-                line "Selected version" "${CYAN}$REF_OVERRIDE${RESET}"
+                ok "Requested version" "$LATEST"
             fi
         fi
     else
-        line "Installation type" "local"
-        [ -n "$REF_OVERRIDE" ] && line "Selected version" "${CYAN}not available for local installs${RESET}"
+        ok "Install source" "local clone"
+        [ -n "$REF_OVERRIDE" ] && info "VERSION ignored for local installs."
     fi
 
     if [ -f "$EXT_DIR/$EXT_FILE" ]; then
-        line "Previous installation" "detected"
-    else
-        line "Previous installation" "not detected"
+        local prev_ver
+        prev_ver=$(get_installed_version)
+        info "Previous installation detected (${prev_ver}) — upgrading."
     fi
 
     echo ""
     detect_pm
     ensure_nautilus_python
     ensure_gettext
+    echo ""
+    info "Downloading files…"
     download_files
     install_files
 
     echo ""
-    echo -e "${BOLD}${CYAN}🚀 Installation completed!${RESET}"
+    printf "${BOLD}${CYAN}  🚀 Installation complete!${RESET}\n"
     offer_restart
+    echo ""
 }
 
 # ─── UNINSTALL ────────────────────────────────────────────────────────────────
 do_uninstall() {
     echo ""
-
     local found=false
 
-    # Extension
     if [ -f "$EXT_DIR/$EXT_FILE" ]; then
-        rm -f "$EXT_DIR/$EXT_FILE"
-        rm -f "$EXT_DIR/__pycache__/nautilus-my-computer.cpython-"*.pyc 2>/dev/null || true
-        line "Extension removed" "$EXT_DIR/$EXT_FILE"
+        rm -f "$EXT_DIR/$EXT_FILE" "$VERSION_FILE"
+        find "$EXT_DIR/__pycache__/" -name "nautilus-my-computer.cpython-*.pyc" \
+            -delete 2>/dev/null || true
+        ok "Extension removed" "$EXT_DIR/$EXT_FILE"
         found=true
     fi
 
-    # Schema
     if [ -f "$USER_SCHEMA_DIR/$SCHEMA_FILE" ]; then
-        gsettings reset-recursively io.github.yannmasoch.nautilus-my-computer 2>/dev/null || true
+        gsettings reset-recursively io.github.yannmasoch.nautilus-my-computer \
+            2>/dev/null || true
         rm -f "$USER_SCHEMA_DIR/$SCHEMA_FILE"
         glib-compile-schemas "$USER_SCHEMA_DIR"
-        line "Preferences removed" "$USER_SCHEMA_DIR/$SCHEMA_FILE"
+        ok "Schema removed" "$USER_SCHEMA_DIR/$SCHEMA_FILE"
         found=true
     fi
 
-    # Translations
     local loc_dir_prefix="$HOME/.local/share/locale"
     local langs_removed=""
     if [ -d "$loc_dir_prefix" ]; then
-        for mo_file in "$loc_dir_prefix"/*/LC_MESSAGES/nautilus-my-computer.mo; do
-            if [ -f "$mo_file" ]; then
-                lang=$(echo "$mo_file" | sed "s|$loc_dir_prefix/\(.*\)/LC_MESSAGES.*|\1|")
-                rm -f "$mo_file"
-                langs_removed="${langs_removed:+$langs_removed, }$lang"
-                found=true
-            fi
-        done
+        while IFS= read -r -d '' mo_file; do
+            local lang
+            lang=$(printf '%s' "$mo_file" \
+                | sed "s|${loc_dir_prefix}/\(.*\)/LC_MESSAGES.*|\1|")
+            rm -f "$mo_file"
+            langs_removed="${langs_removed:+$langs_removed, }$lang"
+            found=true
+        done < <(find "$loc_dir_prefix" \
+            -path "*/LC_MESSAGES/nautilus-my-computer.mo" -print0 2>/dev/null)
     fi
-    [ -n "$langs_removed" ] && line "Translation(s) removed" "$langs_removed"
+    [ -n "$langs_removed" ] && ok "Translations removed" "$langs_removed"
 
     if [ "$found" = false ]; then
-        line "Nothing to uninstall" "extension was not found"
-        print_bye
+        info "Nothing to uninstall — extension was not found."
+        bye
         return
     fi
 
     echo ""
-    echo -e "${BOLD}${CYAN}🗑️  Uninstall completed!${RESET}"
+    printf "${BOLD}${CYAN}  🗑️  Uninstall complete!${RESET}\n"
     offer_restart
+    echo ""
 }
 
 # ─── MAIN MENU ────────────────────────────────────────────────────────────────
+show_sysinfo
+
 if [ -n "$REF_OVERRIDE" ]; then
-    VERSION_LABEL="  ${CYAN}[$REF_OVERRIDE]${RESET}"
+    BRANCH_LABEL="${REF_OVERRIDE}"
 else
-    VERSION_LABEL=""
+    BRANCH_LABEL="${DEFAULT_BRANCH}"
 fi
 
-echo ""
-echo -e "${BOLD}Nautilus My Computer Extension Installer${RESET}"
-printf '%0.s─' {1..40}; echo
-echo ""
-echo -e "1) Install / Update${VERSION_LABEL}"
-echo    "2) Uninstall"
-echo    "3) Exit"
+printf "  ${BOLD}1)${RESET} Install / Update  ${CYAN}[${BRANCH_LABEL}]${RESET}\n"
+printf "  ${BOLD}2)${RESET} Install / Update  ${DIM}[main — stable]${RESET}\n"
+printf "  ${BOLD}3)${RESET} Uninstall\n"
+printf "  ${BOLD}4)${RESET} Exit\n"
 echo ""
 
 choice=""
-ask "Choose an option [1-3]: " choice ""
+ask "  Choose an option [1-4]: " choice ""
+echo ""
 
 case "$choice" in
-    1) do_install ;;
-    2) do_uninstall ;;
-    3) print_bye; exit 0 ;;
-    *) die "Invalid choice: '$choice'" ;;
+    1) 
+        # Forzar la rama por defecto si el usuario no especificó una
+        [ -z "$REF_OVERRIDE" ] && REF_OVERRIDE="$DEFAULT_BRANCH"
+        do_install 
+        ;;
+    2) 
+        REF_OVERRIDE="main"
+        BRANCH_LABEL="main"
+        do_install 
+        ;;
+    3) do_uninstall ;;
+    4) bye; exit 0 ;;
+    *) die "Invalid option: '$choice'" ;;
 esac
 
 } # end main

--- a/io.github.yannmasoch.nautilus-my-computer.gschema.xml
+++ b/io.github.yannmasoch.nautilus-my-computer.gschema.xml
@@ -31,6 +31,11 @@
       <summary>Gradient end color</summary>
       <description>Right color (stop 100%) used when color-mode is gradient</description>
     </key>
+    <key name="hide-system-partitions" type="b">
+      <default>true</default>
+      <summary>Hide system partitions</summary>
+      <description>Hide partitions like boot and EFI</description>
+    </key>
 
   </schema>
 </schemalist>

--- a/nautilus-my-computer.py
+++ b/nautilus-my-computer.py
@@ -420,6 +420,11 @@ def _scan_mounts() -> list[MountInfo]:
     seen: set[str] = set()
     uuid_map = _build_uuid_map()
 
+    hide_boot_efi = False
+    gsettings = _get_gsettings()
+    if gsettings:
+        hide_boot_efi = gsettings.get_boolean("hide-system-partitions")
+
     # Build mountpoint → Gio.Icon / Gio.Mount from VolumeMonitor so we can
     # attach the real hardware icon and GIO handle to each /proc/mounts entry.
     icon_by_path: dict[str, Gio.Icon] = {}
@@ -447,6 +452,8 @@ def _scan_mounts() -> list[MountInfo]:
                 opts = set(options.split(","))
                 gvfs_show = "x-gvfs-show" in opts
                 is_external = any(mountpoint.startswith(p) for p in EXTERNAL_PREFIXES)
+                if hide_boot_efi and mountpoint in ("/boot", "/boot/efi", "/efi"):
+                    continue
                 if (
                     fstype not in REAL_FSTYPES and not gvfs_show and not is_external
                 ) or device in seen:
@@ -1010,6 +1017,8 @@ class MyComputerExtension(GObject.GObject, Nautilus.MenuProvider):
     def _on_settings_changed(self, settings: Gio.Settings, key: str) -> None:
         if key == "start-on-disks":
             self._start_on_disks = settings.get_boolean(key)
+        elif key == "hide-system-partitions":
+            self._schedule_live_refresh()
         elif key in ("color-mode", "custom-color", "gradient-color-1", "gradient-color-2"):
             self._apply_bar_color()
 
@@ -1308,24 +1317,28 @@ class MyComputerExtension(GObject.GObject, Nautilus.MenuProvider):
             if key not in _disk_data:
                 continue
             _disk_data[key] = dataclasses.replace(_disk_data[key], total=total, free=free)
+            m = _disk_data[key]
             for state in self._windows.values():
                 if not self._has_live_stack(state, "apply_usage_updates"):
                     continue
                 if state.get("visible_child") != STACK_DISKINFO:
                     continue
-                self._update_card_usage(state, key, total, free)
+                self._update_card_usage(state, m)
         return GLib.SOURCE_REMOVE
 
-    def _update_card_usage(self, state: dict, key: str, total: int, free: int) -> None:
+    def _update_card_usage(self, state: dict, m: MountInfo) -> None:
         """Update LevelBar and subtext label for a card via the O(1) card_widgets registry."""
-        entry = state.get("card_widgets", {}).get(key)
+        entry = state.get("card_widgets", {}).get(m.key)
         if entry is None:
             return
         bar, sub = entry
-        if bar is not None and total > 0:
-            bar.set_value(min(1.0, (total - free) / total))
-        if sub is not None and total > 0:
-            sub.set_label(f"{_format_size(free)} free of {_format_size(total)}")
+        if bar is not None and m.total > 0:
+            bar.set_value(min(1.0, (m.total - m.free) / m.total))
+        if sub is not None and m.total > 0:
+            base_sub = _("{free} free of {total}").format(
+                free=_format_size(m.free), total=_format_size(m.total)
+            )
+            sub.set_label(f"{base_sub} • {m.fstype}" if m.fstype else base_sub)
 
     def _ensure_usage_poll_running(self) -> None:
         """Arm both usage poll workers if not already running."""
@@ -1669,9 +1682,10 @@ class MyComputerExtension(GObject.GObject, Nautilus.MenuProvider):
             bar.set_name(bname)
             if v > 0:
                 bar_geom[bname] = v
-            sub_text = _("{free} free of {total}").format(
+            base_sub = _("{free} free of {total}").format(
                 free=_format_size(m.free), total=_format_size(m.total)
             )
+            sub_text = f"{base_sub} • {m.fstype}" if m.fstype else base_sub
         else:
             bar.set_visible(False)
             sub_text = nav_uri
@@ -1855,15 +1869,77 @@ class MyComputerExtension(GObject.GObject, Nautilus.MenuProvider):
                 self._do_open(nav_uri, win)
         return True
 
-    def _on_panel_clicked(self, _gesture, _n, _x, _y, win: Gtk.Window) -> None:
+    def _on_panel_clicked(self, gesture, _n, x, y, win: Gtk.Window) -> None:
         state = self._windows.get(win)
         if not state:
             return
-        state["_deselecting"] = True
-        for flow in state.get("section_flows", []):
-            flow.unselect_all()
-        state["_deselecting"] = False
-        state["selected_key"] = None
+        
+        button = gesture.get_current_button()
+        if button == 1:
+            state["_deselecting"] = True
+            for flow in state.get("section_flows", []):
+                flow.unselect_all()
+            state["_deselecting"] = False
+            state["selected_key"] = None
+        elif button == 3:
+            self._show_bg_context_menu(gesture, x, y, win)
+
+    def _show_bg_context_menu(self, gesture, x, y, win: Gtk.Window) -> None:
+        gesture.set_state(Gtk.EventSequenceState.CLAIMED)
+        menu = Gio.Menu()
+        menu.append(_("Browse Network"), "bg.browse-network")
+        menu.append(_("Disks Utility"), "bg.open-disks")
+        menu.append(_("System Monitor"), "bg.open-sysmon")
+        menu.append(_("My Computer Settings"), "bg.open-settings")
+
+        popover = Gtk.PopoverMenu.new_from_model(menu)
+        popover.set_has_arrow(False)
+        popover.set_parent(gesture.get_widget())
+
+        rect = Gdk.Rectangle()
+        rect.x = int(x)
+        rect.y = int(y)
+        rect.width = 1
+        rect.height = 1
+        popover.set_pointing_to(rect)
+
+        ag = Gio.SimpleActionGroup()
+
+        def _on_network(_act, _param):
+            self._navigate(win, "network:///")
+
+        def _on_disks(_act, _param):
+            try:
+                Gio.Subprocess.new(["gnome-disks"], Gio.SubprocessFlags.NONE)
+            except Exception:
+                pass
+
+        def _on_sysmon(_act, _param):
+            try:
+                Gio.Subprocess.new(["gnome-system-monitor"], Gio.SubprocessFlags.NONE)
+            except Exception:
+                pass
+
+        def _on_settings(_act, _param):
+            self._launch_prefs(win)
+
+        for name, callback in [
+            ("browse-network", _on_network),
+            ("open-disks", _on_disks),
+            ("open-sysmon", _on_sysmon),
+            ("open-settings", _on_settings),
+        ]:
+            action = Gio.SimpleAction.new(name, None)
+            action.connect("activate", callback)
+            ag.add_action(action)
+
+        popover.insert_action_group("bg", ag)
+        
+        def _on_closed(pop):
+            pop.unparent()
+
+        popover.connect("closed", _on_closed)
+        popover.popup()
 
     def _on_disk_right_clicked(self, gesture, _n, x, y, win: Gtk.Window, row: Gtk.Box) -> None:
         mount_key = getattr(row, "_mount_key", None)
@@ -2117,6 +2193,12 @@ class MyComputerExtension(GObject.GObject, Nautilus.MenuProvider):
         start_row.set_subtitle(_("Show the disk panel when Nautilus opens"))
         self._gsettings.bind("start-on-disks", start_row, "active", Gio.SettingsBindFlags.DEFAULT)
         gen_group.add(start_row)
+
+        hide_sys_row = Adw.SwitchRow()
+        hide_sys_row.set_title(_("Hide system partitions"))
+        hide_sys_row.set_subtitle(_("Hide boot and EFI drives"))
+        self._gsettings.bind("hide-system-partitions", hide_sys_row, "active", Gio.SettingsBindFlags.DEFAULT)
+        gen_group.add(hide_sys_row)
 
         color_group = Adw.PreferencesGroup()
         color_group.set_title(_("Disk Usage Color"))

--- a/nautilus-my-computer.py
+++ b/nautilus-my-computer.py
@@ -1869,77 +1869,15 @@ class MyComputerExtension(GObject.GObject, Nautilus.MenuProvider):
                 self._do_open(nav_uri, win)
         return True
 
-    def _on_panel_clicked(self, gesture, _n, x, y, win: Gtk.Window) -> None:
+    def _on_panel_clicked(self, _gesture, _n, _x, _y, win: Gtk.Window) -> None:
         state = self._windows.get(win)
         if not state:
             return
-        
-        button = gesture.get_current_button()
-        if button == 1:
-            state["_deselecting"] = True
-            for flow in state.get("section_flows", []):
-                flow.unselect_all()
-            state["_deselecting"] = False
-            state["selected_key"] = None
-        elif button == 3:
-            self._show_bg_context_menu(gesture, x, y, win)
-
-    def _show_bg_context_menu(self, gesture, x, y, win: Gtk.Window) -> None:
-        gesture.set_state(Gtk.EventSequenceState.CLAIMED)
-        menu = Gio.Menu()
-        menu.append(_("Browse Network"), "bg.browse-network")
-        menu.append(_("Disks Utility"), "bg.open-disks")
-        menu.append(_("System Monitor"), "bg.open-sysmon")
-        menu.append(_("My Computer Settings"), "bg.open-settings")
-
-        popover = Gtk.PopoverMenu.new_from_model(menu)
-        popover.set_has_arrow(False)
-        popover.set_parent(gesture.get_widget())
-
-        rect = Gdk.Rectangle()
-        rect.x = int(x)
-        rect.y = int(y)
-        rect.width = 1
-        rect.height = 1
-        popover.set_pointing_to(rect)
-
-        ag = Gio.SimpleActionGroup()
-
-        def _on_network(_act, _param):
-            self._navigate(win, "network:///")
-
-        def _on_disks(_act, _param):
-            try:
-                Gio.Subprocess.new(["gnome-disks"], Gio.SubprocessFlags.NONE)
-            except Exception:
-                pass
-
-        def _on_sysmon(_act, _param):
-            try:
-                Gio.Subprocess.new(["gnome-system-monitor"], Gio.SubprocessFlags.NONE)
-            except Exception:
-                pass
-
-        def _on_settings(_act, _param):
-            self._launch_prefs(win)
-
-        for name, callback in [
-            ("browse-network", _on_network),
-            ("open-disks", _on_disks),
-            ("open-sysmon", _on_sysmon),
-            ("open-settings", _on_settings),
-        ]:
-            action = Gio.SimpleAction.new(name, None)
-            action.connect("activate", callback)
-            ag.add_action(action)
-
-        popover.insert_action_group("bg", ag)
-        
-        def _on_closed(pop):
-            pop.unparent()
-
-        popover.connect("closed", _on_closed)
-        popover.popup()
+        state["_deselecting"] = True
+        for flow in state.get("section_flows", []):
+            flow.unselect_all()
+        state["_deselecting"] = False
+        state["selected_key"] = None
 
     def _on_disk_right_clicked(self, gesture, _n, x, y, win: Gtk.Window, row: Gtk.Box) -> None:
         mount_key = getattr(row, "_mount_key", None)
@@ -2197,7 +2135,9 @@ class MyComputerExtension(GObject.GObject, Nautilus.MenuProvider):
         hide_sys_row = Adw.SwitchRow()
         hide_sys_row.set_title(_("Hide system partitions"))
         hide_sys_row.set_subtitle(_("Hide boot and EFI drives"))
-        self._gsettings.bind("hide-system-partitions", hide_sys_row, "active", Gio.SettingsBindFlags.DEFAULT)
+        self._gsettings.bind(
+            "hide-system-partitions", hide_sys_row, "active", Gio.SettingsBindFlags.DEFAULT
+        )
         gen_group.add(hide_sys_row)
 
         color_group = Adw.PreferencesGroup()

--- a/po/ca.po
+++ b/po/ca.po
@@ -1,0 +1,149 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: nautilus-my-computer\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-06-01 00:00+0200\n"
+"PO-Revision-Date: 2026-06-01 00:00+0200\n"
+"Last-Translator: Unai Lomas\n"
+"Language-Team: Catalan\n"
+"Language: ca\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+
+msgid "My Computer Settings"
+msgstr "Configuració d'Ordinador"
+
+msgid "System"
+msgstr "Sistema"
+
+msgid "Devices and Drives"
+msgstr "Dispositius i unitats"
+
+msgid "Removable Devices"
+msgstr "Dispositius extraïbles"
+
+msgid "Disc Images"
+msgstr "Imatges de disc"
+
+msgid "Network Volumes"
+msgstr "Volums de xarxa"
+
+msgid "Not mounted"
+msgstr "No muntat"
+
+msgid "Format…"
+msgstr "Formatar…"
+
+msgid "General"
+msgstr "General"
+
+msgid "Start on Computer view"
+msgstr "Iniciar a la vista Ordinador"
+
+msgid "Show the disk panel when Nautilus opens"
+msgstr "Mostra el panell de discos en obrir Nautilus"
+
+msgid "Disk Usage Color"
+msgstr "Color d'ús del disc"
+
+msgid "Color mode"
+msgstr "Mode de color"
+
+msgid "System accent"
+msgstr "Color d'accent del sistema"
+
+msgid "Custom color"
+msgstr "Color personalitzat"
+
+msgid "Gradient"
+msgstr "Degradat"
+
+msgid "Color"
+msgstr "Color"
+
+msgid "Start color"
+msgstr "Color inicial"
+
+msgid "End color"
+msgstr "Color final"
+
+msgid "Sidebar Bookmark"
+msgstr "Marcador de la barra lateral"
+
+msgid "The \"Computer\" bookmark gives access to this panel from the sidebar. Restore it here if you accidentally removed it."
+msgstr "El marcador \"Ordinador\" dóna accés a aquest panell des de la barra lateral. Restaureu-lo aquí si l'heu eliminat accidentalment."
+
+msgid "Restore \"Computer\" bookmark"
+msgstr "Restaurar marcador \"Ordinador\""
+
+msgid "Restore"
+msgstr "Restaurar"
+
+msgid "Added ✓"
+msgstr "Afegit ✓"
+
+msgid "About"
+msgstr "Quant a"
+
+msgid "Extension"
+msgstr "Extensió"
+
+msgid "Version"
+msgstr "Versió"
+
+msgid "Author"
+msgstr "Autor"
+
+msgid "License"
+msgstr "Llicència"
+
+msgid "Source code"
+msgstr "Codi font"
+
+msgid "GitHub ↗"
+msgstr "GitHub ↗"
+
+msgid "{free} free of {total}"
+msgstr "{free} lliure de {total}"
+
+msgid "Computer"
+msgstr "Ordinador"
+
+msgid "Mount"
+msgstr "Muntar"
+
+msgid "Unmount"
+msgstr "Desmuntar"
+
+msgid "Eject"
+msgstr "Expulsar"
+
+msgid "Open"
+msgstr "Obrir"
+
+msgid "Open in New Tab"
+msgstr "Obrir en una pestanya nova"
+
+msgid "Open in New Window"
+msgstr "Obrir en una finestra nova"
+
+msgid "Properties"
+msgstr "Propietats"
+
+msgid "Hide system partitions"
+msgstr "Ocultar particions del sistema"
+
+msgid "Hide boot and EFI drives"
+msgstr "Ocultar unitats d'arrencada (Boot i EFI)"
+
+msgid "Browse Network"
+msgstr "Explorar la xarxa"
+
+msgid "Disks Utility"
+msgstr "Utilitat de discs"
+
+msgid "System Monitor"
+msgstr "Monitor del sistema"
+

--- a/po/es.po
+++ b/po/es.po
@@ -1,0 +1,149 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: nautilus-my-computer\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-06-01 00:00+0200\n"
+"PO-Revision-Date: 2026-06-01 00:00+0200\n"
+"Last-Translator: Unai Lomas\n"
+"Language-Team: Spanish\n"
+"Language: es\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+
+msgid "My Computer Settings"
+msgstr "Configuración de Equipo"
+
+msgid "System"
+msgstr "Sistema"
+
+msgid "Devices and Drives"
+msgstr "Dispositivos y unidades"
+
+msgid "Removable Devices"
+msgstr "Dispositivos extraíbles"
+
+msgid "Disc Images"
+msgstr "Imágenes de disco"
+
+msgid "Network Volumes"
+msgstr "Volúmenes de red"
+
+msgid "Not mounted"
+msgstr "No montado"
+
+msgid "Format…"
+msgstr "Formatear…"
+
+msgid "General"
+msgstr "General"
+
+msgid "Start on Computer view"
+msgstr "Iniciar en la vista Equipo"
+
+msgid "Show the disk panel when Nautilus opens"
+msgstr "Mostrar el panel de discos al abrir Nautilus"
+
+msgid "Disk Usage Color"
+msgstr "Color de uso del disco"
+
+msgid "Color mode"
+msgstr "Modo de color"
+
+msgid "System accent"
+msgstr "Color de acento del sistema"
+
+msgid "Custom color"
+msgstr "Color personalizado"
+
+msgid "Gradient"
+msgstr "Degradado"
+
+msgid "Color"
+msgstr "Color"
+
+msgid "Start color"
+msgstr "Color inicial"
+
+msgid "End color"
+msgstr "Color final"
+
+msgid "Sidebar Bookmark"
+msgstr "Marcador de la barra lateral"
+
+msgid "The \"Computer\" bookmark gives access to this panel from the sidebar. Restore it here if you accidentally removed it."
+msgstr "El marcador \"Equipo\" da acceso a este panel desde la barra lateral. Restáurelo aquí si lo ha eliminado accidentalmente."
+
+msgid "Restore \"Computer\" bookmark"
+msgstr "Restaurar marcador \"Equipo\""
+
+msgid "Restore"
+msgstr "Restaurar"
+
+msgid "Added ✓"
+msgstr "Añadido ✓"
+
+msgid "About"
+msgstr "Acerca de"
+
+msgid "Extension"
+msgstr "Extensión"
+
+msgid "Version"
+msgstr "Versión"
+
+msgid "Author"
+msgstr "Autor"
+
+msgid "License"
+msgstr "Licencia"
+
+msgid "Source code"
+msgstr "Código fuente"
+
+msgid "GitHub ↗"
+msgstr "GitHub ↗"
+
+msgid "{free} free of {total}"
+msgstr "{free} libre de {total}"
+
+msgid "Computer"
+msgstr "Equipo"
+
+msgid "Mount"
+msgstr "Montar"
+
+msgid "Unmount"
+msgstr "Desmontar"
+
+msgid "Eject"
+msgstr "Expulsar"
+
+msgid "Open"
+msgstr "Abrir"
+
+msgid "Open in New Tab"
+msgstr "Abrir en una pestaña nueva"
+
+msgid "Open in New Window"
+msgstr "Abrir en una ventana nueva"
+
+msgid "Properties"
+msgstr "Propiedades"
+
+msgid "Hide system partitions"
+msgstr "Ocultar particiones del sistema"
+
+msgid "Hide boot and EFI drives"
+msgstr "Ocultar unidades de arranque (Boot y EFI)"
+
+msgid "Browse Network"
+msgstr "Explorar la red"
+
+msgid "Disks Utility"
+msgstr "Utilidad de discos"
+
+msgid "System Monitor"
+msgstr "Monitor del sistema"
+

--- a/po/it.po
+++ b/po/it.po
@@ -1,0 +1,149 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: nautilus-my-computer\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-06-01 00:00+0200\n"
+"PO-Revision-Date: 2026-06-01 00:00+0200\n"
+"Last-Translator: Unai Lomas\n"
+"Language-Team: Italian\n"
+"Language: it\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+
+msgid "My Computer Settings"
+msgstr "Impostazioni Computer"
+
+msgid "System"
+msgstr "Sistema"
+
+msgid "Devices and Drives"
+msgstr "Dispositivi e unità"
+
+msgid "Removable Devices"
+msgstr "Dispositivi rimovibili"
+
+msgid "Disc Images"
+msgstr "Immagini disco"
+
+msgid "Network Volumes"
+msgstr "Volumi di rete"
+
+msgid "Not mounted"
+msgstr "Non montato"
+
+msgid "Format…"
+msgstr "Formatta…"
+
+msgid "General"
+msgstr "Generale"
+
+msgid "Start on Computer view"
+msgstr "Avvia nella vista Computer"
+
+msgid "Show the disk panel when Nautilus opens"
+msgstr "Mostra il pannello dei dischi all'apertura di Nautilus"
+
+msgid "Disk Usage Color"
+msgstr "Colore utilizzo disco"
+
+msgid "Color mode"
+msgstr "Modalità colore"
+
+msgid "System accent"
+msgstr "Colore accento di sistema"
+
+msgid "Custom color"
+msgstr "Colore personalizzato"
+
+msgid "Gradient"
+msgstr "Sfumatura"
+
+msgid "Color"
+msgstr "Colore"
+
+msgid "Start color"
+msgstr "Colore iniziale"
+
+msgid "End color"
+msgstr "Colore finale"
+
+msgid "Sidebar Bookmark"
+msgstr "Segnalibro della barra laterale"
+
+msgid "The \"Computer\" bookmark gives access to this panel from the sidebar. Restore it here if you accidentally removed it."
+msgstr "Il segnalibro \"Computer\" dà accesso a questo pannello dalla barra laterale. Ripristinalo qui se lo hai rimosso accidentalmente."
+
+msgid "Restore \"Computer\" bookmark"
+msgstr "Ripristina segnalibro \"Computer\""
+
+msgid "Restore"
+msgstr "Ripristina"
+
+msgid "Added ✓"
+msgstr "Aggiunto ✓"
+
+msgid "About"
+msgstr "Informazioni"
+
+msgid "Extension"
+msgstr "Estensione"
+
+msgid "Version"
+msgstr "Versione"
+
+msgid "Author"
+msgstr "Autore"
+
+msgid "License"
+msgstr "Licenza"
+
+msgid "Source code"
+msgstr "Codice sorgente"
+
+msgid "GitHub ↗"
+msgstr "GitHub ↗"
+
+msgid "{free} free of {total}"
+msgstr "{free} disponibile di {total}"
+
+msgid "Computer"
+msgstr "Computer"
+
+msgid "Mount"
+msgstr "Monta"
+
+msgid "Unmount"
+msgstr "Smonta"
+
+msgid "Eject"
+msgstr "Espelli"
+
+msgid "Open"
+msgstr "Apri"
+
+msgid "Open in New Tab"
+msgstr "Apri in una nuova scheda"
+
+msgid "Open in New Window"
+msgstr "Apri in una nuova finestra"
+
+msgid "Properties"
+msgstr "Proprietà"
+
+msgid "Hide system partitions"
+msgstr "Nascondi partizioni di sistema"
+
+msgid "Hide boot and EFI drives"
+msgstr "Nascondi le unità di avvio (Boot e EFI)"
+
+msgid "Browse Network"
+msgstr "Esplora rete"
+
+msgid "Disks Utility"
+msgstr "Gestione dischi"
+
+msgid "System Monitor"
+msgstr "Monitor di sistema"
+

--- a/po/pt.po
+++ b/po/pt.po
@@ -1,0 +1,149 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: nautilus-my-computer\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-06-01 00:00+0200\n"
+"PO-Revision-Date: 2026-06-01 00:00+0200\n"
+"Last-Translator: Unai Lomas\n"
+"Language-Team: Portuguese\n"
+"Language: pt\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+
+msgid "My Computer Settings"
+msgstr "Configurações de Meu Computador"
+
+msgid "System"
+msgstr "Sistema"
+
+msgid "Devices and Drives"
+msgstr "Dispositivos e Unidades"
+
+msgid "Removable Devices"
+msgstr "Dispositivos Removíveis"
+
+msgid "Disc Images"
+msgstr "Imagens de Disco"
+
+msgid "Network Volumes"
+msgstr "Volumes de Rede"
+
+msgid "Not mounted"
+msgstr "Não montado"
+
+msgid "Format…"
+msgstr "Formatar…"
+
+msgid "General"
+msgstr "Geral"
+
+msgid "Start on Computer view"
+msgstr "Iniciar na visualização Computador"
+
+msgid "Show the disk panel when Nautilus opens"
+msgstr "Mostrar o painel de discos ao abrir o Nautilus"
+
+msgid "Disk Usage Color"
+msgstr "Cor de uso do disco"
+
+msgid "Color mode"
+msgstr "Modo de cor"
+
+msgid "System accent"
+msgstr "Destaque do sistema"
+
+msgid "Custom color"
+msgstr "Cor personalizada"
+
+msgid "Gradient"
+msgstr "Gradiente"
+
+msgid "Color"
+msgstr "Cor"
+
+msgid "Start color"
+msgstr "Cor inicial"
+
+msgid "End color"
+msgstr "Cor final"
+
+msgid "Sidebar Bookmark"
+msgstr "Favorito da Barra Lateral"
+
+msgid "The \"Computer\" bookmark gives access to this panel from the sidebar. Restore it here if you accidentally removed it."
+msgstr "O favorito \"Computador\" dá acesso a este painel pela barra lateral. Restaure-o aqui se o removeu acidentalmente."
+
+msgid "Restore \"Computer\" bookmark"
+msgstr "Restaurar favorito \"Computador\""
+
+msgid "Restore"
+msgstr "Restaurar"
+
+msgid "Added ✓"
+msgstr "Adicionado ✓"
+
+msgid "About"
+msgstr "Sobre"
+
+msgid "Extension"
+msgstr "Extensão"
+
+msgid "Version"
+msgstr "Versão"
+
+msgid "Author"
+msgstr "Autor"
+
+msgid "License"
+msgstr "Licença"
+
+msgid "Source code"
+msgstr "Código-fonte"
+
+msgid "GitHub ↗"
+msgstr "GitHub ↗"
+
+msgid "{free} free of {total}"
+msgstr "{free} livre de {total}"
+
+msgid "Computer"
+msgstr "Computador"
+
+msgid "Mount"
+msgstr "Montar"
+
+msgid "Unmount"
+msgstr "Desmontar"
+
+msgid "Eject"
+msgstr "Ejetar"
+
+msgid "Open"
+msgstr "Abrir"
+
+msgid "Open in New Tab"
+msgstr "Abrir em Nova Aba"
+
+msgid "Open in New Window"
+msgstr "Abrir em Nova Janela"
+
+msgid "Properties"
+msgstr "Propriedades"
+
+msgid "Hide system partitions"
+msgstr "Ocultar partições do sistema"
+
+msgid "Hide boot and EFI drives"
+msgstr "Ocultar unidades de inicialização (Boot e EFI)"
+
+msgid "Browse Network"
+msgstr "Navegar na Rede"
+
+msgid "Disks Utility"
+msgstr "Utilitário de Discos"
+
+msgid "System Monitor"
+msgstr "Monitor do Sistema"
+


### PR DESCRIPTION
This pull request introduces a new user preference to hide system partitions (such as boot and EFI) from the disk list in the "My Computer" panel, and adds full translations for Catalan, Spanish, Italian, and Portuguese. It also improves the display of disk information by including the filesystem type in the UI. The most important changes are grouped below:

**New Feature: Hide System Partitions**
* Added a new GSettings key `hide-system-partitions` (default: true) to allow users to hide boot and EFI partitions from the device list (`io.github.yannmasoch.nautilus-my-computer.gschema.xml`).
* Updated the mount scanning logic in `nautilus-my-computer.py` to respect this new setting and skip system partitions accordingly. [[1]](diffhunk://#diff-559c2445ca4a91701c3b69a00efc6ec0cd72f80557a2d35b7861e88aaa17b4ffR423-R427) [[2]](diffhunk://#diff-559c2445ca4a91701c3b69a00efc6ec0cd72f80557a2d35b7861e88aaa17b4ffR455-R456)
* Integrated a toggle for this option in the preferences UI, allowing users to enable or disable hiding system partitions from the settings panel.
* Ensured the UI refreshes when the setting changes.

**User Interface and Usability Improvements**
* Enhanced disk usage display by including the filesystem type (e.g., ext4, vfat) in the card subtext, both when building and updating disk cards. [[1]](diffhunk://#diff-559c2445ca4a91701c3b69a00efc6ec0cd72f80557a2d35b7861e88aaa17b4ffR1320-R1341) [[2]](diffhunk://#diff-559c2445ca4a91701c3b69a00efc6ec0cd72f80557a2d35b7861e88aaa17b4ffL1672-R1688)

**Localization**
* Added new translations for the entire extension in Catalan (`po/ca.po`), Spanish (`po/es.po`), Italian (`po/it.po`), and Portuguese (`po/pt.po`). [[1]](diffhunk://#diff-189655adfb23ba3ecf3b5a1cbfe11ae0656ebd401cffc8ff503d57c08e688abcR1-R139) [[2]](diffhunk://#diff-e489678c415f61892616a7f3ce50c4ffc843c0e1de965c59152a71fbdb388a49R1-R139) [[3]](diffhunk://#diff-15b3c8931fed1524ca3c16709564c6149ceea8a52daac0c0f4b0da14100108c5R1-R139) [[4]](diffhunk://#diff-edfed236d3e21623b0d8a5720f67257b8abaa8ec1808c5c329e9551023415233R1-R139)