### PR TITLE
feat: add hide-system-partitions option and translation files

### DIFF
--- a/io.github.yannmasoch.nautilus-my-computer.gschema.xml
+++ b/io.github.yannmasoch.nautilus-my-computer.gschema.xml
@@ -32,5 +32,11 @@
       <description>Right color (stop 100%) used when color-mode is gradient</description>
     </key>
 
+    <key name="hide-system-partitions" type="b">
+      <default>true</default>
+      <summary>Hide system partitions</summary>
+      <description>Hide partitions like boot and EFI</description>
+    </key>
+
   </schema>
 </schemalist>

--- a/nautilus-my-computer.py
+++ b/nautilus-my-computer.py
@@ -421,6 +421,11 @@ def _scan_mounts() -> list[MountInfo]:
     seen: set[str] = set()
     uuid_map = _build_uuid_map()
 
+    hide_boot_efi = False
+    gsettings = _get_gsettings()
+    if gsettings:
+        hide_boot_efi = gsettings.get_boolean("hide-system-partitions")
+
     # Build mountpoint → Gio.Icon / Gio.Mount from VolumeMonitor so we can
     # attach the real hardware icon and GIO handle to each /proc/mounts entry.
     icon_by_path: dict[str, Gio.Icon] = {}
@@ -451,6 +456,8 @@ def _scan_mounts() -> list[MountInfo]:
                 if (
                     fstype not in REAL_FSTYPES and not gvfs_show and not is_external
                 ) or device in seen:
+                    continue
+                if hide_boot_efi and mountpoint in ("/boot", "/boot/efi", "/efi"):
                     continue
                 seen.add(device)
                 try:
@@ -1043,6 +1050,8 @@ class MyComputerExtension(GObject.GObject, Nautilus.MenuProvider):
             self._start_on_disks = settings.get_boolean(key)
         elif key in ("color-mode", "custom-color", "gradient-color-1", "gradient-color-2"):
             self._apply_bar_color()
+        elif key == "hide-system-partitions":
+            self._schedule_live_refresh()
 
     def _apply_bar_color(self) -> None:
         if not self._gsettings or self._bar_css_display is None:
@@ -1348,7 +1357,14 @@ class MyComputerExtension(GObject.GObject, Nautilus.MenuProvider):
         if bar is not None and total > 0:
             bar.set_value(min(1.0, (total - free) / total))
         if sub is not None and total > 0:
-            sub.set_label(f"{_format_size(free)} free of {_format_size(total)}")
+            m = _disk_data.get(key)
+            base_sub = _("{free} free of {total}").format(
+                free=_format_size(free), total=_format_size(total)
+            )
+            if m and m.fstype:
+                sub.set_label(f"{base_sub} • {m.fstype}")
+            else:
+                sub.set_label(base_sub)
 
     def _ensure_usage_poll_running(self) -> None:
         """Arm both usage poll workers if not already running."""
@@ -1685,9 +1701,10 @@ class MyComputerExtension(GObject.GObject, Nautilus.MenuProvider):
             v = min(m.percent / 100.0, 1.0)
             bar.set_value(v)
             bar.set_visible(True)
-            sub_text = _("{free} free of {total}").format(
+            base_sub = _("{free} free of {total}").format(
                 free=_format_size(m.free), total=_format_size(m.total)
             )
+            sub_text = f"{base_sub} • {m.fstype}" if m.fstype else base_sub
         else:
             bar.set_visible(False)
             sub_text = nav_uri
@@ -2133,6 +2150,14 @@ class MyComputerExtension(GObject.GObject, Nautilus.MenuProvider):
         start_row.set_subtitle(_("Show the disk panel when Nautilus opens"))
         self._gsettings.bind("start-on-disks", start_row, "active", Gio.SettingsBindFlags.DEFAULT)
         gen_group.add(start_row)
+
+        hide_sys_row = Adw.SwitchRow()
+        hide_sys_row.set_title(_("Hide system partitions"))
+        hide_sys_row.set_subtitle(_("Hide boot and EFI drives"))
+        self._gsettings.bind(
+            "hide-system-partitions", hide_sys_row, "active", Gio.SettingsBindFlags.DEFAULT
+        )
+        gen_group.add(hide_sys_row)
 
         color_group = Adw.PreferencesGroup()
         color_group.set_title(_("Disk Usage Color"))

--- a/po/ar.po
+++ b/po/ar.po
@@ -25,7 +25,7 @@ msgid "Removable Devices"
 msgstr "الأجهزة القابلة للإزالة"
 
 msgid "Disc Images"
-msgstr "صور الأقراص"
+msgstr ""
 
 msgid "Network Volumes"
 msgstr "مجلدات الشبكة"
@@ -131,3 +131,9 @@ msgstr "افتح في نافذة جديدة"
 
 msgid "Properties"
 msgstr "الخصائص"
+
+msgid "Hide system partitions"
+msgstr "إخفاء أقسام النظام"
+
+msgid "Hide boot and EFI drives"
+msgstr "إخفاء أقسام الإقلاع و EFI"

--- a/po/ca.po
+++ b/po/ca.po
@@ -1,0 +1,139 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: nautilus-my-computer\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-06-01 00:00+0200\n"
+"PO-Revision-Date: 2026-06-01 00:00+0200\n"
+"Last-Translator: Unai Lomas\n"
+"Language-Team: Catalan\n"
+"Language: ca\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+
+msgid "My Computer Settings"
+msgstr "Configuració d'Ordinador"
+
+msgid "System"
+msgstr "Sistema"
+
+msgid "Devices and Drives"
+msgstr "Dispositius i unitats"
+
+msgid "Removable Devices"
+msgstr "Dispositius extraïbles"
+
+msgid "Disc Images"
+msgstr "Imatges de disc"
+
+msgid "Network Volumes"
+msgstr "Volums de xarxa"
+
+msgid "Not mounted"
+msgstr "No muntat"
+
+msgid "Format…"
+msgstr "Formatar…"
+
+msgid "General"
+msgstr "General"
+
+msgid "Start on Computer view"
+msgstr "Iniciar a la vista Ordinador"
+
+msgid "Show the disk panel when Nautilus opens"
+msgstr "Mostra el panell de discos en obrir Nautilus"
+
+msgid "Disk Usage Color"
+msgstr "Color d'ús del disc"
+
+msgid "Color mode"
+msgstr "Mode de color"
+
+msgid "System accent"
+msgstr "Color d'accent del sistema"
+
+msgid "Custom color"
+msgstr "Color personalitzat"
+
+msgid "Gradient"
+msgstr "Degradat"
+
+msgid "Color"
+msgstr "Color"
+
+msgid "Start color"
+msgstr "Color inicial"
+
+msgid "End color"
+msgstr "Color final"
+
+msgid "Sidebar Bookmark"
+msgstr "Marcador de la barra lateral"
+
+msgid "The \"Computer\" bookmark gives access to this panel from the sidebar. Restore it here if you accidentally removed it."
+msgstr "El marcador \"Ordinador\" dóna accés a aquest panell des de la barra lateral. Restaureu-lo aquí si l'heu eliminat accidentalment."
+
+msgid "Restore \"Computer\" bookmark"
+msgstr "Restaurar marcador \"Ordinador\""
+
+msgid "Restore"
+msgstr "Restaurar"
+
+msgid "Added ✓"
+msgstr "Afegit ✓"
+
+msgid "About"
+msgstr "Quant a"
+
+msgid "Extension"
+msgstr "Extensió"
+
+msgid "Version"
+msgstr "Versió"
+
+msgid "Author"
+msgstr "Autor"
+
+msgid "License"
+msgstr "Llicència"
+
+msgid "Source code"
+msgstr "Codi font"
+
+msgid "GitHub ↗"
+msgstr "GitHub ↗"
+
+msgid "{free} free of {total}"
+msgstr "{free} lliure de {total}"
+
+msgid "Computer"
+msgstr "Ordinador"
+
+msgid "Mount"
+msgstr "Muntar"
+
+msgid "Unmount"
+msgstr "Desmuntar"
+
+msgid "Eject"
+msgstr "Expulsar"
+
+msgid "Open"
+msgstr "Obrir"
+
+msgid "Open in New Tab"
+msgstr "Obrir en una pestanya nova"
+
+msgid "Open in New Window"
+msgstr "Obrir en una finestra nova"
+
+msgid "Properties"
+msgstr "Propietats"
+
+msgid "Hide system partitions"
+msgstr "Ocultar particions del sistema"
+
+msgid "Hide boot and EFI drives"
+msgstr "Ocultar unitats d'arrencada (Boot i EFI)"

--- a/po/es.po
+++ b/po/es.po
@@ -1,0 +1,139 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: nautilus-my-computer\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-06-01 00:00+0200\n"
+"PO-Revision-Date: 2026-06-01 00:00+0200\n"
+"Last-Translator: Unai Lomas\n"
+"Language-Team: Spanish\n"
+"Language: es\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+
+msgid "My Computer Settings"
+msgstr "Configuración de Equipo"
+
+msgid "System"
+msgstr "Sistema"
+
+msgid "Devices and Drives"
+msgstr "Dispositivos y unidades"
+
+msgid "Removable Devices"
+msgstr "Dispositivos extraíbles"
+
+msgid "Disc Images"
+msgstr "Imágenes de disco"
+
+msgid "Network Volumes"
+msgstr "Volúmenes de red"
+
+msgid "Not mounted"
+msgstr "No montado"
+
+msgid "Format…"
+msgstr "Formatear…"
+
+msgid "General"
+msgstr "General"
+
+msgid "Start on Computer view"
+msgstr "Iniciar en la vista Equipo"
+
+msgid "Show the disk panel when Nautilus opens"
+msgstr "Mostrar el panel de discos al abrir Nautilus"
+
+msgid "Disk Usage Color"
+msgstr "Color de uso del disco"
+
+msgid "Color mode"
+msgstr "Modo de color"
+
+msgid "System accent"
+msgstr "Color de acento del sistema"
+
+msgid "Custom color"
+msgstr "Color personalizado"
+
+msgid "Gradient"
+msgstr "Degradado"
+
+msgid "Color"
+msgstr "Color"
+
+msgid "Start color"
+msgstr "Color inicial"
+
+msgid "End color"
+msgstr "Color final"
+
+msgid "Sidebar Bookmark"
+msgstr "Marcador de la barra lateral"
+
+msgid "The \"Computer\" bookmark gives access to this panel from the sidebar. Restore it here if you accidentally removed it."
+msgstr "El marcador \"Equipo\" da acceso a este panel desde la barra lateral. Restáurelo aquí si lo ha eliminado accidentalmente."
+
+msgid "Restore \"Computer\" bookmark"
+msgstr "Restaurar marcador \"Equipo\""
+
+msgid "Restore"
+msgstr "Restaurar"
+
+msgid "Added ✓"
+msgstr "Añadido ✓"
+
+msgid "About"
+msgstr "Acerca de"
+
+msgid "Extension"
+msgstr "Extensión"
+
+msgid "Version"
+msgstr "Versión"
+
+msgid "Author"
+msgstr "Autor"
+
+msgid "License"
+msgstr "Licencia"
+
+msgid "Source code"
+msgstr "Código fuente"
+
+msgid "GitHub ↗"
+msgstr "GitHub ↗"
+
+msgid "{free} free of {total}"
+msgstr "{free} libre de {total}"
+
+msgid "Computer"
+msgstr "Equipo"
+
+msgid "Mount"
+msgstr "Montar"
+
+msgid "Unmount"
+msgstr "Desmontar"
+
+msgid "Eject"
+msgstr "Expulsar"
+
+msgid "Open"
+msgstr "Abrir"
+
+msgid "Open in New Tab"
+msgstr "Abrir en una pestaña nueva"
+
+msgid "Open in New Window"
+msgstr "Abrir en una ventana nueva"
+
+msgid "Properties"
+msgstr "Propiedades"
+
+msgid "Hide system partitions"
+msgstr "Ocultar particiones del sistema"
+
+msgid "Hide boot and EFI drives"
+msgstr "Ocultar unidades de arranque (Boot y EFI)"

--- a/po/fr.po
+++ b/po/fr.po
@@ -131,3 +131,9 @@ msgstr "Ouvrir dans une nouvelle fenêtre"
 
 msgid "Properties"
 msgstr "Propriétés"
+
+msgid "Hide system partitions"
+msgstr "Masquer les partitions système"
+
+msgid "Hide boot and EFI drives"
+msgstr "Masquer les partitions de démarrage (Boot et EFI)"

--- a/po/it.po
+++ b/po/it.po
@@ -1,0 +1,139 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: nautilus-my-computer\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-06-01 00:00+0200\n"
+"PO-Revision-Date: 2026-06-01 00:00+0200\n"
+"Last-Translator: Unai Lomas\n"
+"Language-Team: Italian\n"
+"Language: it\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+
+msgid "My Computer Settings"
+msgstr "Impostazioni Computer"
+
+msgid "System"
+msgstr "Sistema"
+
+msgid "Devices and Drives"
+msgstr "Dispositivi e unità"
+
+msgid "Removable Devices"
+msgstr "Dispositivi rimovibili"
+
+msgid "Disc Images"
+msgstr "Immagini disco"
+
+msgid "Network Volumes"
+msgstr "Volumi di rete"
+
+msgid "Not mounted"
+msgstr "Non montato"
+
+msgid "Format…"
+msgstr "Formatta…"
+
+msgid "General"
+msgstr "Generale"
+
+msgid "Start on Computer view"
+msgstr "Avvia nella vista Computer"
+
+msgid "Show the disk panel when Nautilus opens"
+msgstr "Mostra il pannello dei dischi all'apertura di Nautilus"
+
+msgid "Disk Usage Color"
+msgstr "Colore utilizzo disco"
+
+msgid "Color mode"
+msgstr "Modalità colore"
+
+msgid "System accent"
+msgstr "Colore accento di sistema"
+
+msgid "Custom color"
+msgstr "Colore personalizzato"
+
+msgid "Gradient"
+msgstr "Sfumatura"
+
+msgid "Color"
+msgstr "Colore"
+
+msgid "Start color"
+msgstr "Colore iniziale"
+
+msgid "End color"
+msgstr "Colore finale"
+
+msgid "Sidebar Bookmark"
+msgstr "Segnalibro della barra laterale"
+
+msgid "The \"Computer\" bookmark gives access to this panel from the sidebar. Restore it here if you accidentally removed it."
+msgstr "Il segnalibro \"Computer\" dà accesso a questo pannello dalla barra laterale. Ripristinalo qui se lo hai rimosso accidentalmente."
+
+msgid "Restore \"Computer\" bookmark"
+msgstr "Ripristina segnalibro \"Computer\""
+
+msgid "Restore"
+msgstr "Ripristina"
+
+msgid "Added ✓"
+msgstr "Aggiunto ✓"
+
+msgid "About"
+msgstr "Informazioni"
+
+msgid "Extension"
+msgstr "Estensione"
+
+msgid "Version"
+msgstr "Versione"
+
+msgid "Author"
+msgstr "Autore"
+
+msgid "License"
+msgstr "Licenza"
+
+msgid "Source code"
+msgstr "Codice sorgente"
+
+msgid "GitHub ↗"
+msgstr "GitHub ↗"
+
+msgid "{free} free of {total}"
+msgstr "{free} disponibile di {total}"
+
+msgid "Computer"
+msgstr "Computer"
+
+msgid "Mount"
+msgstr "Monta"
+
+msgid "Unmount"
+msgstr "Smonta"
+
+msgid "Eject"
+msgstr "Espelli"
+
+msgid "Open"
+msgstr "Apri"
+
+msgid "Open in New Tab"
+msgstr "Apri in una nuova scheda"
+
+msgid "Open in New Window"
+msgstr "Apri in una nuova finestra"
+
+msgid "Properties"
+msgstr "Proprietà"
+
+msgid "Hide system partitions"
+msgstr "Nascondi partizioni di sistema"
+
+msgid "Hide boot and EFI drives"
+msgstr "Nascondi le unità di avvio (Boot e EFI)"

--- a/po/pt.po
+++ b/po/pt.po
@@ -1,0 +1,139 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: nautilus-my-computer\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-06-01 00:00+0200\n"
+"PO-Revision-Date: 2026-06-01 00:00+0200\n"
+"Last-Translator: Unai Lomas\n"
+"Language-Team: Portuguese\n"
+"Language: pt\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+
+msgid "My Computer Settings"
+msgstr "Configurações de Meu Computador"
+
+msgid "System"
+msgstr "Sistema"
+
+msgid "Devices and Drives"
+msgstr "Dispositivos e Unidades"
+
+msgid "Removable Devices"
+msgstr "Dispositivos Removíveis"
+
+msgid "Disc Images"
+msgstr "Imagens de Disco"
+
+msgid "Network Volumes"
+msgstr "Volumes de Rede"
+
+msgid "Not mounted"
+msgstr "Não montado"
+
+msgid "Format…"
+msgstr "Formatar…"
+
+msgid "General"
+msgstr "Geral"
+
+msgid "Start on Computer view"
+msgstr "Iniciar na visualização Computador"
+
+msgid "Show the disk panel when Nautilus opens"
+msgstr "Mostrar o painel de discos ao abrir o Nautilus"
+
+msgid "Disk Usage Color"
+msgstr "Cor de uso do disco"
+
+msgid "Color mode"
+msgstr "Modo de cor"
+
+msgid "System accent"
+msgstr "Destaque do sistema"
+
+msgid "Custom color"
+msgstr "Cor personalizada"
+
+msgid "Gradient"
+msgstr "Gradiente"
+
+msgid "Color"
+msgstr "Cor"
+
+msgid "Start color"
+msgstr "Cor inicial"
+
+msgid "End color"
+msgstr "Cor final"
+
+msgid "Sidebar Bookmark"
+msgstr "Favorito da Barra Lateral"
+
+msgid "The \"Computer\" bookmark gives access to this panel from the sidebar. Restore it here if you accidentally removed it."
+msgstr "O favorito \"Computador\" dá acesso a este painel pela barra lateral. Restaure-o aqui se o removeu acidentalmente."
+
+msgid "Restore \"Computer\" bookmark"
+msgstr "Restaurar favorito \"Computador\""
+
+msgid "Restore"
+msgstr "Restaurar"
+
+msgid "Added ✓"
+msgstr "Adicionado ✓"
+
+msgid "About"
+msgstr "Sobre"
+
+msgid "Extension"
+msgstr "Extensão"
+
+msgid "Version"
+msgstr "Versão"
+
+msgid "Author"
+msgstr "Autor"
+
+msgid "License"
+msgstr "Licença"
+
+msgid "Source code"
+msgstr "Código-fonte"
+
+msgid "GitHub ↗"
+msgstr "GitHub ↗"
+
+msgid "{free} free of {total}"
+msgstr "{free} livre de {total}"
+
+msgid "Computer"
+msgstr "Computador"
+
+msgid "Mount"
+msgstr "Montar"
+
+msgid "Unmount"
+msgstr "Desmontar"
+
+msgid "Eject"
+msgstr "Ejetar"
+
+msgid "Open"
+msgstr "Abrir"
+
+msgid "Open in New Tab"
+msgstr "Abrir em Nova Aba"
+
+msgid "Open in New Window"
+msgstr "Abrir em Nova Janela"
+
+msgid "Properties"
+msgstr "Propriedades"
+
+msgid "Hide system partitions"
+msgstr "Ocultar partições do sistema"
+
+msgid "Hide boot and EFI drives"
+msgstr "Ocultar unidades de inicialização (Boot e EFI)"


### PR DESCRIPTION
This PR introduces a few quality-of-life features, UI improvements, and expands localizations:
1. **Option to hide system partitions**: Adds a toggle to filter out `/boot`, `/boot/efi`, and `/efi` mount points from the main view.
2. **Filesystem type display**: Displays the filesystem format (e.g., `ext4`, `btrfs`, `ntfs`) in the storage usage details subtext.
3. **New translations & updates**: Adds new translations for **Spanish, Catalan, Italian, and Portuguese**, and updates the existing Arabic and French translations with the new preference strings.
---
### Changes
#### 🔧 Schema & Preferences
- Added `hide-system-partitions` GSettings key (`boolean`, default: `true`).
- Added a "Hide system partitions" SwitchRow in the General section of the Preferences window.
- Handled live refresh updates when the GSettings key is toggled.
#### 🖥️ UI / Disk Cards
- Included `fstype` info next to the space-free subtext inside both `_update_card_usage` and `_build_disk_card`.
- Filtered system partition mount points during `_scan_mounts()` when the setting is active.
#### 🌐 Localizations (`po/`)
- Added: `es.po` (Spanish), `ca.po` (Catalan), `it.po` (Italian), and `pt.po` (Portuguese).
- Updated: `ar.po` (Arabic) and `fr.po` (French) with the new preference strings.