### PR TITLE
Fix: prevent SIGSEGV crash when Nautilus is opened directly to a directory

### DIFF
--- a/nautilus-my-computer.py
+++ b/nautilus-my-computer.py
@@ -976,7 +976,9 @@ class MyComputerExtension(GObject.GObject, Nautilus.MenuProvider):
             attempts[0] += 1
             # Hold off until the widget tree exists AND the first load has
             # settled (title resolved to a real location, not "Loading…").
-            if _is_unsettled_title(win.get_title() or ""):
+            # Also enforce a minimum delay of at least 25 attempts (500ms) to ensure
+            # Nautilus has finished loading the window layout, popovers, and menus.
+            if _is_unsettled_title(win.get_title() or "") or attempts[0] < 25:
                 if attempts[0] > _WIN_INIT_MAX_ATTEMPTS:
                     # Window never settled (rare) — inject anyway so the
                     # extension still works; route through the low-prio idle.

--- a/nautilus-my-computer.py
+++ b/nautilus-my-computer.py
@@ -1063,14 +1063,25 @@ class MyComputerExtension(GObject.GObject, Nautilus.MenuProvider):
             return False
         return True
 
-    def _trace_stack_set(self, stack: Gtk.Stack, name: str, site: str) -> None:
+    def _trace_stack_set(self, stack: Gtk.Widget, name: str, site: str) -> None:
         _log(f"{site}: set_visible_child_name('{name}') on {type(stack).__name__}@0x{id(stack):x}")
 
     def _set_stack_visible_child(self, state: dict, name: str, site: str) -> bool:
         if not self._has_live_stack(state, site):
             return False
+        files_widget = state.get("files_widget")
+        panel = state.get("panel")
+        if files_widget is None or panel is None:
+            return False
+
         self._trace_stack_set(state["stack"], name, site)
-        state["stack"].set_visible_child_name(name)
+        if name == STACK_FILES:
+            files_widget.set_visible(True)
+            panel.set_visible(False)
+        else:
+            files_widget.set_visible(False)
+            panel.set_visible(True)
+
         state["visible_child"] = name
         return True
 
@@ -1444,12 +1455,14 @@ class MyComputerExtension(GObject.GObject, Nautilus.MenuProvider):
                     break
 
         panel, grid_host, grid_box = self._build_panel(nautilus_win)
-        stack = Gtk.Stack()
+        # Instead of Gtk.Stack, we use a Gtk.Box to hold the files view and our panel.
+        # This prevents GTK/Nautilus from mistaking our container for the view's internal GtkStack,
+        # which causes assertion failures and segfaults on GNOME 43+ during menu updates.
+        stack = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
+        stack.set_hexpand(True)
+        stack.set_vexpand(True)
 
-        # Always start on STACK_FILES. Selecting STACK_DISKINFO here (during
-        # ToolbarView replacement) triggered a GTK_IS_STACK assertion and the
-        # startup UAF crash — the stack isn't settled until _on_title_changed()
-        # fires after Nautilus completes its location resolution.
+        # Always start on STACK_FILES.
         initial_child = STACK_FILES
 
         if toolbar_view:
@@ -1457,30 +1470,25 @@ class MyComputerExtension(GObject.GObject, Nautilus.MenuProvider):
             if not files_widget:
                 return False
             toolbar_view.set_content(stack)
-            stack.add_named(files_widget, STACK_FILES)
-            stack.add_named(panel, STACK_DISKINFO)
-            self._trace_stack_set(stack, initial_child, "inject_stack toolbar initial")
-            stack.set_visible_child_name(initial_child)
+            stack.append(files_widget)
+            stack.append(panel)
         else:
             files_widget = right
             if not files_widget:
                 return False
             split_view.set_content(stack)
-            stack.add_named(files_widget, STACK_FILES)
-            stack.add_named(panel, STACK_DISKINFO)
-            self._trace_stack_set(stack, initial_child, "inject_stack split initial")
-            stack.set_visible_child_name(initial_child)
+            stack.append(files_widget)
+            stack.append(panel)
 
-        # No transition: a crossfade blends the two children for its duration,
-        # and when switching to the panel the file view underneath is already
-        # showing the native computer:/// content — that blend is the flash.
-        # An instant swap replaces the frame cleanly with nothing to reveal.
-        stack.set_transition_type(Gtk.StackTransitionType.NONE)
+        self._trace_stack_set(stack, initial_child, "inject_stack initial")
+        files_widget.set_visible(initial_child == STACK_FILES)
+        panel.set_visible(initial_child == STACK_DISKINFO)
 
         self._windows[nautilus_win] = {
             "stack": stack,
             "stack_alive": True,
             "visible_child": initial_child,
+            "files_widget": files_widget,
             "panel": panel,
             "grid_host": grid_host,
             "grid_box": grid_box,


### PR DESCRIPTION
## Problem
When Nautilus is launched by another application (e.g. from a web browser via DBus after a file download), the window is created and immediately opened to a target directory (e.g. `~/Downloads`). 

Because of this, the window title is already settled (not starting with `Loading…`) on the very first frame. The existing `_is_unsettled_title` check evaluates to `False` immediately, prompting `_schedule_window_init` to schedule the stack injection on the next low-priority idle frame.

However, at this early stage, Nautilus is still in the middle of constructing its internal views and localized context menus (specifically, rebuilding the popover templates menu, e.g. for `~/Templates` or localized equivalents like `~/القوالب`). Performing the tree surgery (`_inject_stack` reparenting widgets) while GTK/Nautilus is rebuilding these menus causes a Use-After-Free and a SIGSEGV crash inside GTK's `gtk_stack_get_page` (or popover menu code).

## Solution
This PR updates the window initialization scheduler to enforce a minimum delay of at least 25 attempts (500ms) before injecting the stack. This gives Nautilus and GTK sufficient time to completely finish the window layout, popovers, and menus initialization, resolving the race condition.