### PR TITLE
Fix zypper package

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -88,7 +88,7 @@ detect_pm() {
     if   command -v pacman  >/dev/null 2>&1; then PM=pacman;  NP_PKG="python-nautilus"
     elif command -v apt-get >/dev/null 2>&1; then PM=apt;     NP_PKG="python3-nautilus"
     elif command -v dnf     >/dev/null 2>&1; then PM=dnf;     NP_PKG="nautilus-python"
-    elif command -v zypper  >/dev/null 2>&1; then PM=zypper;  NP_PKG="python3-nautilus"
+    elif command -v zypper  >/dev/null 2>&1; then PM=zypper;  NP_PKG="python313-nautilus"
     else die "Cannot detect package manager. Install nautilus-python manually and re-run."
     fi
     line "Package manager" "$PM"

--- a/po/de.po
+++ b/po/de.po
@@ -1,0 +1,181 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: nautilus-my-computer\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-06-01 00:00+0200\n"
+"PO-Revision-Date: 2026-06-01 00:00+0200\n"
+"Last-Translator: Martin Endres\n"
+"Language-Team: German\n"
+"Language: de\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+
+#——————————————————————————————
+# Panel - Group labels
+#——————————————————————————————
+
+msgid "On this Computer"
+msgstr "Auf diesem Computer"
+
+msgid "System"
+msgstr "System"
+
+msgid "Removable"
+msgstr "Entfernbar"
+
+msgid "Disc"
+msgstr "Datenträger"
+
+msgid "Network Volumes"
+msgstr "Netzwerk-Volumes"
+
+#——————————————————————————————
+# Panel - Disk card
+#——————————————————————————————
+
+msgid "{free} free of {total}"
+msgstr "{free} frei von {total}"
+
+msgid "Not mounted"
+msgstr "Nicht eingehängt"
+
+#——————————————————————————————
+# Panel - Disk card actions
+#——————————————————————————————
+
+msgid "Open"
+msgstr "Öffnen"
+
+msgid "Open in New Tab"
+msgstr "In neuem Tab öffnen"
+
+msgid "Open in New Window"
+msgstr "In neuem Fenster öffnen"
+
+msgid "Mount"
+msgstr "Einhängen"
+
+msgid "Unmount"
+msgstr "Aushängen"
+
+msgid "Eject"
+msgstr "Auswerfen"
+
+msgid "Properties"
+msgstr "Eigenschaften"
+
+msgid "Format…"
+msgstr "Formatieren…"
+
+#——————————————————————————————
+# Sidebar
+#——————————————————————————————
+
+msgid "Computer"
+msgstr "Computer"
+
+msgid "Open My Computer"
+msgstr "My Computer öffnen"
+
+#——————————————————————————————
+# Preferences - General
+#——————————————————————————————
+
+msgid "My Computer Settings"
+msgstr "Einstellungen von My Computer"
+
+msgid "General"
+msgstr "Allgemein"
+
+msgid "Start on the Computer view"
+msgstr "In der Computeransicht starten"
+
+msgid "Launch directly to the Computer view instead of Home"
+msgstr "Starte direkt in der Computeransicht statt auf der Startseite"
+
+#——————————————————————————————
+# Preferences - Bar Color
+#——————————————————————————————
+
+msgid "Bar Color"
+msgstr "Balkenfarbe"
+
+msgid "Select or customize the bar color."
+msgstr "Balkenfarbe auswählen oder anpassen."
+
+msgid "Color mode"
+msgstr "Farbmodus"
+
+msgid "System accent"
+msgstr "Akzentfarbe"
+
+msgid "Custom color"
+msgstr "Benutzerdefinierte Farbe"
+
+msgid "Custom gradient"
+msgstr "Benutzerdefinierter Farbverlauf"
+
+msgid "Color"
+msgstr "Farbe"
+
+msgid "Start color"
+msgstr "Startfarbe"
+
+msgid "End color"
+msgstr "Endfarbe"
+
+#——————————————————————————————
+# Preferences - Visibility
+#——————————————————————————————
+
+msgid "Visibility"
+msgstr "Sichtbarkeit"
+
+msgid "Choose how each group appears. Visible: shows the group as a normal separated section. Merged: folds the group into the On this Computer group. Hidden: hides the group entirely."
+msgstr "Wählen Sie, wie jede Gruppe angezeigt wird. Sichtbar: zeigt die Gruppe als normalen separaten Bereich an. Zusammengeführt: führt die Gruppe in die Gruppe Auf diesem Computer ein. Versteckt: versteckt die Gruppe vollständig."
+
+msgid "Visible"
+msgstr "Sichtbar"
+
+msgid "Merged"
+msgstr "Zusammengeführt"
+
+msgid "Hidden"
+msgstr "Versteckt"
+
+#——————————————————————————————
+# Preferences - System
+#——————————————————————————————
+
+msgid "Show system partitions"
+msgstr "Systempartitionen anzeigen"
+
+msgid "Include boot and EFI partitions in the System group"
+msgstr "Boot- und EFI-Partitionen in der Gruppe System einbeziehen"
+
+#——————————————————————————————
+# Preferences - About
+#——————————————————————————————
+
+msgid "About"
+msgstr "Info"
+
+msgid "Extension"
+msgstr "Erweiterung"
+
+msgid "Version"
+msgstr "Version"
+
+msgid "Author"
+msgstr "Autor"
+
+msgid "License"
+msgstr "Lizenz"
+
+msgid "Source code"
+msgstr "Quellcode"
+
+msgid "GitHub"
+msgstr "GitHub"


### PR DESCRIPTION
Installing the extension fails on openSUSE Tumbleweed, because there is no package named python3-nautilus. Corrected to python313-nautilus.