### PR TITLE
Fix context menu options

### DIFF
--- a/nautilus-my-computer.py
+++ b/nautilus-my-computer.py
@@ -454,8 +454,9 @@ def _disk_context_menu(ext, win, m) -> ContextualMenu:
 
     # Section 1: mount / unmount / eject + format (non-system only).
     if not is_system and not (m.mountpoint == "/home" or m.mountpoint.startswith("/home/")):
-        if not is_mounted and m.can_mount:
-            items.append(MenuItem(_("Mount"), action=lambda: ext._do_mount(m, win), section=1))
+        if not is_mounted:
+            if m.can_mount:
+                items.append(MenuItem(_("Mount"), action=lambda: ext._do_mount(m, win), section=1))
         elif m.can_eject:
             items.append(MenuItem(_("Eject"), action=lambda: ext._do_eject(m), section=1))
         elif m.can_unmount:

--- a/nautilus-my-computer.py
+++ b/nautilus-my-computer.py
@@ -411,7 +411,7 @@ def _disk_context_menu(ext, win, m) -> ContextualMenu:
     """
     nav_uri = m.nav_uri or (Gio.File.new_for_path(m.mountpoint).get_uri() if m.mountpoint else "")
     is_mounted = m.is_mounted
-    is_system = m.mountpoint == "/"
+    is_system = _is_system_mount(m)
     device = m.device or ""
     if not device.startswith("/dev/") and m.gio_volume:
         unix_dev = m.gio_volume.get_identifier(Gio.VOLUME_IDENTIFIER_KIND_UNIX_DEVICE)

--- a/nautilus-my-computer.py
+++ b/nautilus-my-computer.py
@@ -453,7 +453,7 @@ def _disk_context_menu(ext, win, m) -> ContextualMenu:
         ]
 
     # Section 1: mount / unmount / eject + format (non-system only).
-    if not is_system and m.mountpoint != "/home":
+    if not is_system and not (m.mountpoint == "/home" or m.mountpoint.startswith("/home/")):
         if not is_mounted and m.can_mount:
             items.append(MenuItem(_("Mount"), action=lambda: ext._do_mount(m, win), section=1))
         elif m.can_eject:
@@ -3196,7 +3196,8 @@ class MyComputerExtension(GObject.GObject, Nautilus.MenuProvider):
         self, win: Gtk.Window, entry: PlaceEntry, nautilus_sidebar: Gtk.Widget | None = None
     ) -> Gtk.ListBoxRow:
         # Only the Computer row is built here (it has no native equivalent). Every
-        # other place stays native; we just toggle its native row's visibility.
+        # other place stays native; we only hide the ones toggled off via settings.
+
         row_label = entry.label
         row_tooltip = entry.tooltip
         icon_name = entry.icon

--- a/nautilus-my-computer.py
+++ b/nautilus-my-computer.py
@@ -3196,8 +3196,7 @@ class MyComputerExtension(GObject.GObject, Nautilus.MenuProvider):
         self, win: Gtk.Window, entry: PlaceEntry, nautilus_sidebar: Gtk.Widget | None = None
     ) -> Gtk.ListBoxRow:
         # Only the Computer row is built here (it has no native equivalent). Every
-        # other place stays native; we only hide the ones toggled off via settings.
-
+        # other place stays native; we just toggle its native row's visibility.
         row_label = entry.label
         row_tooltip = entry.tooltip
         icon_name = entry.icon

--- a/nautilus-my-computer.py
+++ b/nautilus-my-computer.py
@@ -454,11 +454,11 @@ def _disk_context_menu(ext, win, m) -> ContextualMenu:
 
     # Section 1: mount / unmount / eject + format (non-system only).
     if not is_system and m.mountpoint != "/home":
-        if not is_mounted:
+        if not is_mounted and m.can_mount:
             items.append(MenuItem(_("Mount"), action=lambda: ext._do_mount(m, win), section=1))
         elif m.can_eject:
             items.append(MenuItem(_("Eject"), action=lambda: ext._do_eject(m), section=1))
-        else:
+        elif m.can_unmount:
             items.append(MenuItem(_("Unmount"), action=lambda: ext._do_unmount(m), section=1))
         if device.startswith("/dev/"):
             items.append(MenuItem(_("Format…"), action=lambda: ext._do_format(device), section=1))
@@ -509,6 +509,8 @@ class MountInfo:
     is_mounted: bool = True
     is_removable: bool = False
     can_eject: bool = False
+    can_mount: bool = False
+    can_unmount: bool = False
     is_network_place: bool = False
 
     # Right-click menu factory menu(ext, win, m) -> ContextualMenu (built at show-time).
@@ -911,6 +913,7 @@ def _scan_mounts(show_system_partitions: bool = False) -> list[MountInfo]:
                                 or (gio_mount and gio_mount.can_eject())
                                 or (gio_drive and gio_drive.can_eject())
                             ),
+                            can_unmount=bool(gio_mount and gio_mount.can_unmount()),
                         )
                     )
                 except OSError:
@@ -976,6 +979,7 @@ def _scan_gio_mounts() -> list[MountInfo]:
                         or mount.can_eject()
                         or (gio_drive and gio_drive.can_eject())
                     ),
+                    can_unmount=bool(mount.can_unmount()),
                 )
             )
     except Exception:
@@ -1014,7 +1018,8 @@ def _scan_gio_volumes() -> list[MountInfo]:
                     is_removable=is_removable,
                     gio_icon=volume.get_icon(),
                     gio_volume=volume,
-                    can_eject=bool(volume.can_eject() or (drive and drive.can_eject())),
+                            can_eject=bool(volume.can_eject() or (drive and drive.can_eject())),
+                            can_mount=bool(getattr(volume, "can_mount", lambda: False)() if volume else False),
                 )
             )
     except Exception:
@@ -2739,7 +2744,7 @@ class MyComputerExtension(GObject.GObject, Nautilus.MenuProvider):
         subprocess.Popen(["nautilus", "--new-window", mountpoint])
 
     def _do_mount(self, m: MountInfo, win: Gtk.Window) -> None:
-        if not m or not m.gio_volume:
+        if not m or not m.gio_volume or not m.can_mount:
             return
         op = Gio.MountOperation.new()
         m.gio_volume.mount(Gio.MountMountFlags.NONE, op, None, self._on_mount_finish, win)
@@ -2752,7 +2757,7 @@ class MyComputerExtension(GObject.GObject, Nautilus.MenuProvider):
         GLib.idle_add(self._repopulate_visible)
 
     def _do_mount_then_open(self, m: MountInfo, win: Gtk.Window, mode: str) -> None:
-        if not m or not m.gio_volume:
+        if not m or not m.gio_volume or not m.can_mount:
             return
         op = Gio.MountOperation.new()
         op.set_password_save(Gio.PasswordSave.NEVER)
@@ -2782,7 +2787,7 @@ class MyComputerExtension(GObject.GObject, Nautilus.MenuProvider):
             GLib.idle_add(self._do_open, uri, win)
 
     def _do_unmount(self, m: MountInfo) -> None:
-        if not m or not m.gio_mount:
+        if not m or not m.gio_mount or not m.can_unmount:
             return
         op = Gio.MountOperation.new()
         m.gio_mount.unmount_with_operation(

--- a/nautilus-my-computer.py
+++ b/nautilus-my-computer.py
@@ -1020,9 +1020,7 @@ def _scan_gio_volumes() -> list[MountInfo]:
                     gio_icon=volume.get_icon(),
                     gio_volume=volume,
                     can_eject=bool(volume.can_eject() or (drive and drive.can_eject())),
-                    can_mount=bool(
-                        getattr(volume, "can_mount", lambda: False)() if volume else False
-                    ),
+                    can_mount=bool(volume.can_mount()),
                 )
             )
     except Exception:

--- a/nautilus-my-computer.py
+++ b/nautilus-my-computer.py
@@ -453,7 +453,7 @@ def _disk_context_menu(ext, win, m) -> ContextualMenu:
         ]
 
     # Section 1: mount / unmount / eject + format (non-system only).
-    if not is_system:
+    if not is_system and m.mountpoint != "/home":
         if not is_mounted:
             items.append(MenuItem(_("Mount"), action=lambda: ext._do_mount(m, win), section=1))
         elif m.can_eject:

--- a/nautilus-my-computer.py
+++ b/nautilus-my-computer.py
@@ -1018,8 +1018,10 @@ def _scan_gio_volumes() -> list[MountInfo]:
                     is_removable=is_removable,
                     gio_icon=volume.get_icon(),
                     gio_volume=volume,
-                            can_eject=bool(volume.can_eject() or (drive and drive.can_eject())),
-                            can_mount=bool(getattr(volume, "can_mount", lambda: False)() if volume else False),
+                    can_eject=bool(volume.can_eject() or (drive and drive.can_eject())),
+                    can_mount=bool(
+                        getattr(volume, "can_mount", lambda: False)() if volume else False
+                    ),
                 )
             )
     except Exception:


### PR DESCRIPTION
The context menu displays an Unmount option for the EFI partition and an Unmount- and Format option for the home partition. In addition, devices which were mounted manually or through /etc/fstab can’t be properly unmounted.

I changed the behavior to not display these options for all system- and home partitions, and devices mounted manually or through /etc/fstab.