### PR TITLE
Enable search functionality in My Computer for network drives

### DIFF
--- a/nautilus-my-computer.py
+++ b/nautilus-my-computer.py
@@ -1933,8 +1933,7 @@ class MyComputerExtension(GObject.GObject, Nautilus.MenuProvider):
         # it would reparent/unmap and risk the GTK_IS_STACK crash). Toggle only
         # the panel overlay's visibility. The panel is FILL/FILL and absorbs all
         # pointer events without needing set_sensitive() on the base. Keyboard
-        # type-ahead is blocked separately by the capture-phase key guard
-        # (_on_window_key_capture). Do NOT call set_sensitive() on the base
+        # type-ahead is allowed natively by Nautilus. Do NOT call set_sensitive() on the base
         # (AdwTabView): it covers all tabs, so toggling it disrupts Nautilus
         # keyboard controllers on other tabs and causes freezes in multi-tab.
         panel.set_visible(name == VIEW_DISKINFO)
@@ -2471,43 +2470,9 @@ class MyComputerExtension(GObject.GObject, Nautilus.MenuProvider):
             )
         )
 
-        # Capture-phase key guard on the window: Nautilus's "type to search"
-        # type-ahead is hooked above keyboard focus, so neither hiding nor
-        # de-focusing the covered file view stops it. A controller at the top of
-        # the capture chain sees keystrokes first and swallows plain printable
-        # ones while the panel is shown — so typing doesn't reopen the vanilla
-        # computer:/// search. Modified shortcuts (Ctrl/Alt/Super) and control
-        # keys (arrows, Tab, Enter, Esc) always pass through.
-        key_guard = Gtk.EventControllerKey()
-        key_guard.set_propagation_phase(Gtk.PropagationPhase.CAPTURE)
-        key_guard.connect("key-pressed", self._on_window_key_capture, nautilus_win)
-        nautilus_win.add_controller(key_guard)
-
         # If this window is headed to computer:///, let the later title-change
         # path do the first populate + switch once Nautilus has settled.
 
-        return True
-
-    def _on_window_key_capture(self, _ctrl, keyval, _keycode, gtk_state, win) -> bool:
-        """Swallow plain printable keystrokes while our panel is shown, so
-        Nautilus's window-level type-ahead search doesn't reopen the file view."""
-        state = self._windows.get(win)
-        if not state or state.get("visible_view") != VIEW_DISKINFO:
-            return False
-        # Let modified shortcuts through (Ctrl+L, Alt+Left, Super, …).
-        if gtk_state & (
-            Gdk.ModifierType.CONTROL_MASK | Gdk.ModifierType.ALT_MASK | Gdk.ModifierType.SUPER_MASK
-        ):
-            return False
-        # Only swallow printable characters (>= space). Control keys — arrows,
-        # Tab, Enter, Esc, function keys — map to unicode < 0x20 and pass through.
-        if Gdk.keyval_to_unicode(keyval) < 0x20:
-            return False
-        # If the user opened a text entry (Ctrl+L location bar, Ctrl+F search),
-        # the focused widget is an Editable — let it receive the keystroke.
-        focused = win.get_focus()
-        if focused is not None and isinstance(focused, Gtk.Editable):
-            return False
         return True
 
     # ── Panel construction ────────────────────────────────────────────────────

--- a/nautilus-my-computer.py
+++ b/nautilus-my-computer.py
@@ -2567,8 +2567,14 @@ class MyComputerExtension(GObject.GObject, Nautilus.MenuProvider):
 
         bg_deselect = Gtk.GestureClick()
         bg_deselect.set_button(0)
+        bg_deselect.set_button(1)
         bg_deselect.connect("pressed", self._on_panel_clicked, win)
         scroll.add_controller(bg_deselect)
+
+        bg_right_click = Gtk.GestureClick()
+        bg_right_click.set_button(3)
+        bg_right_click.connect("pressed", self._on_panel_right_clicked, win)
+        scroll.add_controller(bg_right_click)
 
         return panel, scroll, grid_box
 
@@ -3593,6 +3599,255 @@ class MyComputerExtension(GObject.GObject, Nautilus.MenuProvider):
         state["_deselecting"] = False
         state["selected_mount_key"] = None
         state["selected_folder_key"] = None
+
+    def _on_panel_right_clicked(self, gesture, _n, x, y, win: Gtk.Window) -> None:
+        gesture.set_state(Gtk.EventSequenceState.CLAIMED)
+        state = self._windows.get(win)
+        if not state:
+            return
+
+        menu = Gio.Menu()
+        ag = Gio.SimpleActionGroup()
+
+        connect_sec = Gio.Menu()
+        connect_sec.append(_("Connect to Server…"), "panelbg.connect-server")
+        menu.append_section(None, connect_sec)
+
+        settings_sec = Gio.Menu()
+        settings_sec.append(MENU_ITEM_LABEL, "panelbg.settings")
+        menu.append_section(None, settings_sec)
+
+        connect_act = Gio.SimpleAction.new("connect-server", None)
+        connect_act.connect("activate", lambda *_: self._show_connect_dialog(win))
+        ag.add_action(connect_act)
+
+        settings_act = Gio.SimpleAction.new("settings", None)
+        settings_act.connect("activate", lambda *_: self._launch_prefs(win))
+        ag.add_action(settings_act)
+
+        panel = state.get("panel")
+        if panel is None:
+            return
+        panel.insert_action_group("panelbg", ag)
+
+        popover = Gtk.PopoverMenu.new_from_model(menu)
+        popover.set_has_arrow(False)
+        popover.set_parent(panel)
+        rect = Gdk.Rectangle()
+        rect.x, rect.y, rect.width, rect.height = int(x), int(y), 1, 1
+        popover.set_pointing_to(rect)
+        popover.popup()
+
+    # ── Connect to Server dialog ──────────────────────────────────────────────
+
+    # Protocol definitions: (display_label, uri_scheme, default_port, fields)
+    # fields is a tuple of booleans: (share, folder, port, user, domain)
+    _PROTOCOLS = [
+        ("Windows Share (SMB)",  "smb",    None, (True,  True,  False, False, True)),
+        ("SSH / SFTP",          "sftp",   22,   (False, True,  True,  True,  False)),
+        ("FTP",                 "ftp",    21,   (False, True,  True,  True,  False)),
+        ("FTP (" + _("encrypted") + ")", "ftps", 990, (False, True, True, True, False)),
+        ("WebDAV (HTTP)",       "dav",    80,   (False, True,  True,  True,  False)),
+        ("WebDAV (HTTPS)",      "davs",   443,  (False, True,  True,  True,  False)),
+    ]
+
+    def _show_connect_dialog(self, win: Gtk.Window) -> None:
+        """Show a dialog to enter network server details and connect."""
+        dialog = Adw.Dialog()
+        dialog.set_title(_("Connect to Server"))
+        dialog.set_content_width(480)
+        dialog.set_content_height(-1)
+
+        toolbar_view = Adw.ToolbarView()
+        header = Adw.HeaderBar()
+        toolbar_view.add_top_bar(header)
+
+        content = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=0)
+        content.set_margin_start(24)
+        content.set_margin_end(24)
+        content.set_margin_top(12)
+        content.set_margin_bottom(24)
+
+        # ── Protocol selector ─────────────────────────────────────────────
+        proto_group = Adw.PreferencesGroup()
+        proto_row = Adw.ComboRow()
+        proto_row.set_title(_("Protocol"))
+        proto_labels = [p[0] for p in self._PROTOCOLS]
+        proto_row.set_model(Gtk.StringList.new(proto_labels))
+        proto_row.set_selected(0)
+        proto_group.add(proto_row)
+        content.append(proto_group)
+
+        # ── Server details group ──────────────────────────────────────────
+        details_group = Adw.PreferencesGroup()
+        details_group.set_margin_top(18)
+
+        server_row = Adw.EntryRow()
+        server_row.set_title(_("Server address"))
+        details_group.add(server_row)
+
+        share_row = Adw.EntryRow()
+        share_row.set_title(_("Share"))
+        details_group.add(share_row)
+
+        folder_row = Adw.EntryRow()
+        folder_row.set_title(_("Folder"))
+        details_group.add(folder_row)
+
+        port_row = Adw.EntryRow()
+        port_row.set_title(_("Port"))
+        details_group.add(port_row)
+
+        content.append(details_group)
+
+        # ── Authentication group ──────────────────────────────────────────
+        auth_group = Adw.PreferencesGroup()
+        auth_group.set_title(_("Authentication"))
+        auth_group.set_margin_top(18)
+
+        user_row = Adw.EntryRow()
+        user_row.set_title(_("User"))
+        auth_group.add(user_row)
+
+        domain_row = Adw.EntryRow()
+        domain_row.set_title(_("Domain"))
+        auth_group.add(domain_row)
+
+        content.append(auth_group)
+
+        # ── Connect button ────────────────────────────────────────────────
+        connect_btn = Gtk.Button(label=_("Connect"))
+        connect_btn.add_css_class("suggested-action")
+        connect_btn.add_css_class("pill")
+        connect_btn.set_margin_top(24)
+        connect_btn.set_halign(Gtk.Align.CENTER)
+        connect_btn.set_size_request(200, -1)
+        content.append(connect_btn)
+
+        # ── Status label (shown on error) ─────────────────────────────────
+        status_label = Gtk.Label()
+        status_label.set_margin_top(12)
+        status_label.set_wrap(True)
+        status_label.add_css_class("error")
+        status_label.set_visible(False)
+        content.append(status_label)
+
+        toolbar_view.set_content(content)
+        dialog.set_child(toolbar_view)
+
+        # ── Field visibility per protocol ─────────────────────────────────
+        def _update_fields(*_args):
+            idx = proto_row.get_selected()
+            _label, _scheme, default_port, (f_share, f_folder, f_port, f_user, f_domain) = (
+                self._PROTOCOLS[idx]
+            )
+            share_row.set_visible(f_share)
+            folder_row.set_visible(f_folder)
+            port_row.set_visible(f_port)
+            user_row.set_visible(f_user)
+            domain_row.set_visible(f_domain)
+            if f_port and default_port is not None:
+                port_row.set_text(str(default_port))
+            elif not f_port:
+                port_row.set_text("")
+
+        proto_row.connect("notify::selected", _update_fields)
+        _update_fields()  # initial state
+
+        # ── Connect action ────────────────────────────────────────────────
+        def _do_connect(*_args):
+            idx = proto_row.get_selected()
+            _label, scheme, default_port, (f_share, f_folder, f_port, f_user, f_domain) = (
+                self._PROTOCOLS[idx]
+            )
+            server = server_row.get_text().strip()
+            if not server:
+                status_label.set_label(_("Server address is required."))
+                status_label.set_visible(True)
+                return
+
+            # Build the URI
+            user_part = ""
+            if f_user:
+                user = user_row.get_text().strip()
+                if f_domain:
+                    domain = domain_row.get_text().strip()
+                    if domain and user:
+                        user_part = f"{domain};{user}@"
+                    elif user:
+                        user_part = f"{user}@"
+                elif user:
+                    user_part = f"{user}@"
+
+            port_part = ""
+            if f_port:
+                port_text = port_row.get_text().strip()
+                if port_text:
+                    try:
+                        port_num = int(port_text)
+                        if port_num != default_port:
+                            port_part = f":{port_num}"
+                    except ValueError:
+                        status_label.set_label(_("Invalid port number."))
+                        status_label.set_visible(True)
+                        return
+
+            path_part = ""
+            if f_share:
+                share = share_row.get_text().strip().strip("/")
+                folder = folder_row.get_text().strip().strip("/")
+                if share:
+                    path_part = f"/{share}"
+                    if folder:
+                        path_part += f"/{folder}"
+            elif f_folder:
+                folder = folder_row.get_text().strip().strip("/")
+                if folder:
+                    path_part = f"/{folder}"
+
+            uri = f"{scheme}://{user_part}{server}{port_part}{path_part}"
+            _log(f"connect-to-server: mounting {uri}")
+
+            status_label.set_visible(False)
+            connect_btn.set_sensitive(False)
+            connect_btn.set_label(_("Connecting…"))
+
+            gfile = Gio.File.new_for_uri(uri)
+            op = Gtk.MountOperation.new(win)
+
+            def _mount_done(source, result):
+                try:
+                    gfile.mount_enclosing_volume_finish(result)
+                except GLib.Error as e:
+                    if e.matches(Gio.io_error_quark(), Gio.IOErrorEnum.ALREADY_MOUNTED):
+                        _log(f"connect-to-server: already mounted, opening {uri}")
+                    elif e.matches(Gio.io_error_quark(), Gio.IOErrorEnum.CANCELLED):
+                        _log("connect-to-server: cancelled by user")
+                        connect_btn.set_sensitive(True)
+                        connect_btn.set_label(_("Connect"))
+                        return
+                    else:
+                        _log(f"connect-to-server: mount failed: {e.message}")
+                        status_label.set_label(str(e.message))
+                        status_label.set_visible(True)
+                        connect_btn.set_sensitive(True)
+                        connect_btn.set_label(_("Connect"))
+                        return
+
+                dialog.close()
+                self._schedule_live_refresh()
+                GLib.idle_add(self._navigate_to, uri, win)
+
+            gfile.mount_enclosing_volume(
+                Gio.MountMountFlags.NONE, op, None, _mount_done
+            )
+
+        connect_btn.connect("clicked", _do_connect)
+        # Also allow Enter in any entry row to trigger connect
+        for entry in (server_row, share_row, folder_row, port_row, user_row, domain_row):
+            entry.connect("entry-activated", _do_connect)
+
+        dialog.present(win)
 
     def _on_disk_right_clicked(self, gesture, _n, x, y, win: Gtk.Window, row: Gtk.Box) -> None:
         mount_key = getattr(row, "_mount_key", None)

--- a/po/ca.po
+++ b/po/ca.po
@@ -255,3 +255,52 @@ msgstr "Afegeix a preferides"
 
 msgid "Remove from Preferred"
 msgstr "Elimina de preferides"
+
+#——————————————————————————————
+# Network Drives
+#——————————————————————————————
+
+msgid "Connect to Server…"
+msgstr "Connecta't al servidor…"
+
+msgid "Connect to Server"
+msgstr "Connecta't al servidor"
+
+msgid "Protocol"
+msgstr "Protocol"
+
+msgid "Server address"
+msgstr "Adreça del servidor"
+
+msgid "Share"
+msgstr "Recurs compartit"
+
+msgid "Folder"
+msgstr "Carpeta"
+
+msgid "Port"
+msgstr "Port"
+
+msgid "Authentication"
+msgstr "Autenticació"
+
+msgid "User"
+msgstr "Usuari"
+
+msgid "Domain"
+msgstr "Domini"
+
+msgid "Connect"
+msgstr "Connecta"
+
+msgid "Connecting…"
+msgstr "Connectant…"
+
+msgid "Server address is required."
+msgstr "L'adreça del servidor és obligatòria."
+
+msgid "Invalid port number."
+msgstr "Número de port no vàlid."
+
+msgid "encrypted"
+msgstr "xifrat"

--- a/po/es.po
+++ b/po/es.po
@@ -255,3 +255,52 @@ msgstr "Añadir a preferidas"
 
 msgid "Remove from Preferred"
 msgstr "Quitar de preferidas"
+
+#——————————————————————————————
+# Network Drives
+#——————————————————————————————
+
+msgid "Connect to Server…"
+msgstr "Conectarse al servidor…"
+
+msgid "Connect to Server"
+msgstr "Conectarse al servidor"
+
+msgid "Protocol"
+msgstr "Protocolo"
+
+msgid "Server address"
+msgstr "Dirección del servidor"
+
+msgid "Share"
+msgstr "Recurso compartido"
+
+msgid "Folder"
+msgstr "Carpeta"
+
+msgid "Port"
+msgstr "Puerto"
+
+msgid "Authentication"
+msgstr "Autenticación"
+
+msgid "User"
+msgstr "Usuario"
+
+msgid "Domain"
+msgstr "Dominio"
+
+msgid "Connect"
+msgstr "Conectar"
+
+msgid "Connecting…"
+msgstr "Conectando…"
+
+msgid "Server address is required."
+msgstr "La dirección del servidor es obligatoria."
+
+msgid "Invalid port number."
+msgstr "Número de puerto inválido."
+
+msgid "encrypted"
+msgstr "cifrado"

--- a/po/it.po
+++ b/po/it.po
@@ -255,3 +255,52 @@ msgstr "Aggiungi alle preferite"
 
 msgid "Remove from Preferred"
 msgstr "Rimuovi dalle preferite"
+
+#——————————————————————————————
+# Network Drives
+#——————————————————————————————
+
+msgid "Connect to Server…"
+msgstr "Connetti al server…"
+
+msgid "Connect to Server"
+msgstr "Connetti al server"
+
+msgid "Protocol"
+msgstr "Protocollo"
+
+msgid "Server address"
+msgstr "Indirizzo del server"
+
+msgid "Share"
+msgstr "Condivisione"
+
+msgid "Folder"
+msgstr "Cartella"
+
+msgid "Port"
+msgstr "Porta"
+
+msgid "Authentication"
+msgstr "Autenticazione"
+
+msgid "User"
+msgstr "Utente"
+
+msgid "Domain"
+msgstr "Dominio"
+
+msgid "Connect"
+msgstr "Connetti"
+
+msgid "Connecting…"
+msgstr "Connessione in corso…"
+
+msgid "Server address is required."
+msgstr "L'indirizzo del server è richiesto."
+
+msgid "Invalid port number."
+msgstr "Numero di porta non valido."
+
+msgid "encrypted"
+msgstr "cifrato"

--- a/po/pt.po
+++ b/po/pt.po
@@ -255,3 +255,52 @@ msgstr "Adicionar às preferidas"
 
 msgid "Remove from Preferred"
 msgstr "Remover das preferidas"
+
+#——————————————————————————————
+# Network Drives
+#——————————————————————————————
+
+msgid "Connect to Server…"
+msgstr "Ligar ao servidor…"
+
+msgid "Connect to Server"
+msgstr "Ligar ao servidor"
+
+msgid "Protocol"
+msgstr "Protocolo"
+
+msgid "Server address"
+msgstr "Endereço do servidor"
+
+msgid "Share"
+msgstr "Partilha"
+
+msgid "Folder"
+msgstr "Pasta"
+
+msgid "Port"
+msgstr "Porta"
+
+msgid "Authentication"
+msgstr "Autenticação"
+
+msgid "User"
+msgstr "Utilizador"
+
+msgid "Domain"
+msgstr "Domínio"
+
+msgid "Connect"
+msgstr "Ligar"
+
+msgid "Connecting…"
+msgstr "A ligar…"
+
+msgid "Server address is required."
+msgstr "O endereço do servidor é obrigatório."
+
+msgid "Invalid port number."
+msgstr "Número de porta inválido."
+
+msgid "encrypted"
+msgstr "encriptado"

--- a/test_focus.py
+++ b/test_focus.py
@@ -1,0 +1,5 @@
+import gi
+gi.require_version('Gtk', '4.0')
+from gi.repository import Gtk
+def on_focus(win, param):
+    print("focus changed to", win.get_focus())


### PR DESCRIPTION
This pull request introduces a new "Connect to Server" feature in the Nautilus My Computer panel, allowing users to mount network drives via a graphical dialog, and adds translations for this feature in Catalan, Spanish, Italian, and Portuguese. It also refines panel interaction handling and removes the custom key event guard, relying on Nautilus's native type-ahead behavior.

**New "Connect to Server" feature:**

- Added a right-click context menu on the panel background with "Connect to Server…" and "Settings" options. Selecting "Connect to Server…" opens a dialog for connecting to network servers (SMB, SFTP, FTP, WebDAV, etc.), with protocol-specific fields and error handling. The dialog builds the appropriate URI and mounts the network drive, handling authentication and errors gracefully. (`nautilus-my-computer.py`)
- Added translations for all new UI strings related to network drives in Catalan, Spanish, Italian, and Portuguese. (`po/ca.po`, `po/es.po`, `po/it.po`, `po/pt.po`) [[1]](diffhunk://#diff-189655adfb23ba3ecf3b5a1cbfe11ae0656ebd401cffc8ff503d57c08e688abcR258-R306) [[2]](diffhunk://#diff-e489678c415f61892616a7f3ce50c4ffc843c0e1de965c59152a71fbdb388a49R258-R306) [[3]](diffhunk://#diff-15b3c8931fed1524ca3c16709564c6149ceea8a52daac0c0f4b0da14100108c5R258-R306) [[4]](diffhunk://#diff-edfed236d3e21623b0d8a5720f67257b8abaa8ec1808c5c329e9551023415233R258-R306)

**Panel interaction and event handling:**

- Improved panel background click handling: left-click (button 1) now deselects items, and right-click (button 3) opens the new context menu. (`nautilus-my-computer.py`)
- Removed the custom capture-phase key event guard and its handler, relying on Nautilus's native type-ahead search handling to avoid keyboard focus issues and simplify the code. (`nautilus-my-computer.py`) [[1]](diffhunk://#diff-559c2445ca4a91701c3b69a00efc6ec0cd72f80557a2d35b7861e88aaa17b4ffL2474-L2512) [[2]](diffhunk://#diff-559c2445ca4a91701c3b69a00efc6ec0cd72f80557a2d35b7861e88aaa17b4ffL1936-R1936)

**Other:**

- Added a minimal test script for focus changes in GTK 4 (`test_focus.py`).

<img width="400" alt="image" src="https://github.com/user-attachments/assets/12d9b050-bdd3-4356-8cf8-25fb5c8d43f4" />
