### PR TITLE
GNOME 47 Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ My Computer is compatible with almost all custom GTK themes.
 
 | | Distro | GNOME Files | Status |
 |---|--------|-------------|--------|
+| ✅ | stillOS 10.2 | 47.X | Pre-installed |
 | ✅ | Arch | 50.2.2 | Fully working |
 | ✅ | openSUSE Tumbleweed | 50.2.2 | Fully working |
 | ✅ | Fedora 44 Workstation | 50.2.2 | Fully working |
@@ -157,7 +158,7 @@ My Computer is compatible with almost all custom GTK themes.
 | ✅ | Ubuntu 26.04 LTS | 50.0 | Fully working |
 | ☑️ | Zorin OS 18 | 46.4 | Partial, background colors and the My Computer menu entry are not available (Zorin ships a customised build of GNOME Files). Will be improved in a future release |
 
-> GNOME Files versions below 50 may have limited functionality. Full support targets GNOME Files 50+.
+> Full support targets GNOME Files 47–50.
 
 ## Languages
 

--- a/nautilus_my_computer/main.py
+++ b/nautilus_my_computer/main.py
@@ -1661,32 +1661,41 @@ class MyComputerExtension(GObject.GObject, Nautilus.MenuProvider):
         row_tooltip = entry.tooltip
         icon_name = self._get_computer_icon() if entry.uri == DISKS_URI else entry.icon
 
-        # Try to instantiate NautilusSidebarRow directly from the Nautilus GObject
-        # type system. It is registered at runtime when Nautilus loads, so
-        # GObject.type_from_name() can find it. uri is construct-only.
+        # Instantiate the native row directly from Nautilus's GObject type
+        # system. Nautilus 47 calls it NautilusGtkSidebarRow; 48+ calls it
+        # NautilusSidebarRow. Both are registered before extensions load and
+        # expose the same construct-only uri and sidebar properties.
         list_row = None
         try:
             row_gtype = GObject.type_from_name("NautilusSidebarRow")
-            row_props = {
-                "uri": entry.uri,
-                "place-type": 0,  # NAUTILUS_SIDEBAR_ROW_INVALID, sorts before built-in rows
-                "section-type": 1,  # NAUTILUS_SIDEBAR_SECTION_DEFAULT_LOCATIONS
-                "order-index": entry.order_index,
-                "label": row_label,
-                "tooltip": row_tooltip,
-                "eject-tooltip": _("Unmount"),
-                "start-icon": Gio.ThemedIcon.new(icon_name),
-            }
-            if nautilus_sidebar is not None:
-                row_props["sidebar"] = nautilus_sidebar
+        except RuntimeError:
+            # PyGObject raises for unknown names rather than returning
+            # TYPE_INVALID. Nautilus 47 registers only the older name.
+            row_gtype = GObject.type_from_name("NautilusGtkSidebarRow")
+        row_props = {
+            "uri": entry.uri,
+            "place-type": 0,  # NAUTILUS_SIDEBAR_ROW_INVALID, sorts before built-in rows
+            "section-type": 1,  # NAUTILUS_SIDEBAR_SECTION_DEFAULT_LOCATIONS
+            "order-index": entry.order_index,
+            "label": row_label,
+            "tooltip": row_tooltip,
+            "eject-tooltip": _("Unmount"),
+            "start-icon": Gio.ThemedIcon.new(icon_name),
+        }
+        if nautilus_sidebar is not None:
+            row_props["sidebar"] = nautilus_sidebar
 
+        try:
             list_row = GObject.new(row_gtype, **row_props)
             list_row.set_name(f"place_{entry.name}")
             list_row.set_has_tooltip(True)
-            _log(f"_build_place_sidebar_row: NautilusSidebarRow created (uri={entry.uri})")
+            _log(
+                f"_build_place_sidebar_row: {GObject.type_name(row_gtype)} created"
+                f" (uri={entry.uri})"
+            )
         except Exception as e:
             _log(
-                f"_build_place_sidebar_row: NautilusSidebarRow unavailable ({e}),"
+                f"_build_place_sidebar_row: native row construction failed ({e}),"
                 " using GtkListBoxRow"
             )
 

--- a/nautilus_my_computer/widgets.py
+++ b/nautilus_my_computer/widgets.py
@@ -744,7 +744,12 @@ class MyComputerCardSection(Gtk.Box):
         self.flow.set_selection_mode(Gtk.SelectionMode.SINGLE)
         self.flow.set_activate_on_single_click(ext._click_policy == "single")
         self.flow.set_hexpand(True)
-        self.flow.set_halign(Gtk.Align.START if justify and not is_list else Gtk.Align.FILL)
+        # GTK 4.16 (used by Nautilus 47) does not allocate spare horizontal
+        # space to an expanding FlowBox whose halign is START. That leaves the
+        # justified folder flow one card wide while its height was measured for
+        # a full-width row, so following sections overlap it. FILL gives the
+        # flow the width its spacing/allocation code expects on 47 and 48+.
+        self.flow.set_halign(Gtk.Align.FILL)
         self.flow.set_valign(Gtk.Align.START)
 
         self.flow.connect("child-activated", ext._on_card_activated, win)


### PR DESCRIPTION
Adds support for Nautilus 47.

The main changes are checking for either NautilusGtkSidebarRow or NautilusSidebarRow because the name of the type changed with the release of Nautilus 48. Also changed the Flowbox to always be fill to prevent folders from overlapping the rest of the app inside List View.

Before:
<img width="1082" height="830" alt="Screenshot From 2026-07-04 13-34-14" src="https://github.com/user-attachments/assets/8adc789e-4b3f-4abb-8ef2-4aa2014bbf36" />

After:
<img width="1091" height="830" alt="image" src="https://github.com/user-attachments/assets/df5c3577-bddc-4f70-a1bb-f85bd6192842" />
<img width="1091" height="830" alt="image" src="https://github.com/user-attachments/assets/a44a19d6-23fb-4a02-9681-653930da0ab5" />
